### PR TITLE
multipathd: Do not attempt to start multipath-tools in containers.

### DIFF
--- a/multipathd/multipathd.service
+++ b/multipathd/multipathd.service
@@ -8,6 +8,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!multipath=off
+ConditionVirtualization=!container
 
 [Service]
 Type=notify


### PR DESCRIPTION
Originally reported in Ubuntu: https://pad.lv/1823093.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>