### PR TITLE
Add a -1 flag for disabling systemd integration

### DIFF
--- a/multipathd/multipathd.8
+++ b/multipathd/multipathd.8
@@ -84,6 +84,12 @@ Since kernel 4.14 a new device-mapper event polling interface is used for updati
 multipath devices on dmevents. Use this flag to force it to use the old event
 waiting method, based on creating a seperate thread for each device.
 .
+.TP
+.B \-1
+Disable systemd \fIsd_notify()\fR calls. Useful in early boot where systemd
+is not yet available. Roughly equivalent to compiling \fBmultipath-tools\fR with
+\fIUSE_SYSTEMD\fR disabled.
+.
 .
 .
 .\" ----------------------------------------------------------------------------


### PR DESCRIPTION
Support disabling systemd notification integration at run time.

In some deployments of mulitpathd, systemd is ultimately used but not
in stage-1 of boot. In this scenario multipathd is used to mount the
root volume, and then switch_root runs, and we call systemd.

For this use case it is possible to "just" have two copies of
multipathd around, one with and one without systemd support, but it
is a bit tricky and annoying to juggle the two.