### PR TITLE
Bump version to 0.8.8

### DIFF
--- a/libmultipath/version.h
+++ b/libmultipath/version.h
@@ -20,8 +20,8 @@
 #ifndef _VERSION_H
 #define _VERSION_H
 
-#define VERSION_CODE 0x000807
-#define DATE_CODE    0x090815
+#define VERSION_CODE 0x000808
+#define DATE_CODE    0x030c15
 
 #define PROG    "multipath-tools"
 


### PR DESCRIPTION
Hi Christophe,

With the late changes to multipath-tools, we should increase the
version number.

I wasn't sure whether you want to keep this for yourself. You're
of course free to do so. But in case you agree with bumping the
version, here's PR ready for tagging :-)

Regards
Martin
