### PR TITLE
Add missing include <assert.h>

### DIFF
--- a/libmultipath/checkers.c
+++ b/libmultipath/checkers.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <urcu.h>
 #include <urcu/uatomic.h>
+#include <assert.h>
 
 #include "debug.h"
 #include "checkers.h"


### PR DESCRIPTION
checkers.c: In function 'start_checker_thread':
checkers.c:392:9: error: implicit declaration of function 'assert' [-Werror=implicit-function-declaration]
  392 |         assert(ctx && ctx->cls && ctx->cls->thread);
      |         ^~~~~~
checkers.c:13:1: note: 'assert' is defined in header '<assert.h>'; did you forget to '#include <assert.h>'?