### PR TITLE
multipathd/fpin_handlers.c: include stdint.h

### DIFF
--- a/multipathd/fpin_handlers.c
+++ b/multipathd/fpin_handlers.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <unistd.h>
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <libudev.h>


### PR DESCRIPTION
Include `stdint.h` to avoid the following build failure since version 0.8.9 and commit cfff03efbca753ef485ad717087464dced9c721a:

```
In file included from /nvmedata/autobuild/instance-7/output-1/host/nios2-buildroot-linux-gnu/sysroot/usr/include/scsi/scsi_netlink_fc.h:25,
                 from fpin_handlers.c:6:
/nvmedata/autobuild/instance-7/output-1/host/nios2-buildroot-linux-gnu/sysroot/usr/include/scsi/scsi_netlink.h:44:2: error: unknown type name 'uint8_t'
   44 |  uint8_t version;
      |  ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/32f4ada6c49261924ca78f62dee43241bda379a3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>