### PR TITLE
Makefile.inc: Enable systemd if ENABLE_SYSTEMD is defined

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -37,6 +37,7 @@ ifndef RUN
 	endif
 endif
 
+ifdef ENABLE_SYSTEMD
 ifndef SYSTEMD
 	ifeq ($(shell $(PKGCONFIG) --modversion libsystemd >/dev/null 2>&1 && echo 1), 1)
 		SYSTEMD = $(shell $(PKGCONFIG) --modversion libsystemd | awk '{print $$1}')
@@ -46,6 +47,7 @@ ifndef SYSTEMD
 				sed -n 's/systemd \([0-9]*\).*/\1/p')
 		endif
 	endif
+endif
 endif
 
 ifndef SYSTEMDPATH


### PR DESCRIPTION
systemd is disabled by default, to activate it set `ENABLE_SYSTEMD`.

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>
[Retrived from:
https://git.buildroot.net/buildroot/tree/package/multipath-tools/0002-Makefile.inc-Enable-systemd-if-ENABLE_SYSTEMD-is-def.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>