### PR TITLE
multipathd: replace libreadline with fgets()

### DIFF
--- a/multipathd/cli.c
+++ b/multipathd/cli.c
@@ -11,7 +11,6 @@
 #include "parser.h"
 #include "util.h"
 #include "version.h"
-#include <readline/readline.h>
 
 #include "mpath_cmd.h"
 #include "cli.h"
@@ -452,110 +451,4 @@ void cli_exit(void)
 	free_handlers();
 	free_keys(keys);
 	keys = NULL;
-}
-
-static int
-key_match_fingerprint (struct key * kw, uint64_t fp)
-{
-	if (!fp)
-		return 0;
-
-	return ((fp & kw->code) == kw->code);
-}
-
-/*
- * This is the readline completion handler
- */
-char *
-key_generator (const char * str, int state)
-{
-	static int index, len, has_param;
-	static uint64_t rlfp;
-	struct key * kw;
-	int i;
-	struct handler *h;
-	vector v = NULL;
-
-	if (!state) {
-		index = 0;
-		has_param = 0;
-		rlfp = 0;
-		len = strlen(str);
-		int r = get_cmdvec(rl_line_buffer, &v);
-		/*
-		 * If a word completion is in progress, we don't want
-		 * to take an exact keyword match in the fingerprint.
-		 * For ex "show map[tab]" would validate "map" and discard
-		 * "maps" as a valid candidate.
-		 */
-		if (v && len)
-			vector_del_slot(v, VECTOR_SIZE(v) - 1);
-		/*
-		 * Clean up the mess if we dropped the last slot of a 1-slot
-		 * vector
-		 */
-		if (v && !VECTOR_SIZE(v)) {
-			vector_free(v);
-			v = NULL;
-		}
-		/*
-		 * If last keyword takes a param, don't even try to guess
-		 */
-		if (r == EINVAL) {
-			has_param = 1;
-			return (strdup("(value)"));
-		}
-		/*
-		 * Compute a command fingerprint to find out possible completions.
-		 * Once done, the vector is useless. Free it.
-		 */
-		if (v) {
-			rlfp = fingerprint(v);
-			free_keys(v);
-		}
-	}
-	/*
-	 * No more completions for parameter placeholder.
-	 * Brave souls might try to add parameter completion by walking paths and
-	 * multipaths vectors.
-	 */
-	if (has_param)
-		return ((char *)NULL);
-	/*
-	 * Loop through keywords for completion candidates
-	 */
-	vector_foreach_slot_after (keys, kw, index) {
-		if (!strncmp(kw->str, str, len)) {
-			/*
-			 * Discard keywords already in the command line
-			 */
-			if (key_match_fingerprint(kw, rlfp)) {
-				struct key * curkw = find_key(str);
-				if (!curkw || (curkw != kw))
-					continue;
-			}
-			/*
-			 * Discard keywords making syntax errors.
-			 *
-			 * nfp is the candidate fingerprint we try to
-			 * validate against all known command fingerprints.
-			 */
-			uint64_t nfp = rlfp | kw->code;
-			vector_foreach_slot(handlers, h, i) {
-				if (!rlfp || ((h->fingerprint & nfp) == nfp)) {
-					/*
-					 * At least one full command is
-					 * possible with this keyword :
-					 * Consider it validated
-					 */
-					index++;
-					return (strdup(kw->str));
-				}
-			}
-		}
-	}
-	/*
-	 * No more candidates
-	 */
-	return ((char *)NULL);
 }

--- a/multipathd/uxclnt.c
+++ b/multipathd/uxclnt.c
@@ -15,8 +15,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <poll.h>
-#include <readline/readline.h>
-#include <readline/history.h>
+#include <ctype.h>
 
 #include "mpath_cmd.h"
 #include "uxsock.h"
@@ -70,20 +69,20 @@ static int need_quit(char *str, size_t len)
  */
 static void process(int fd, unsigned int timeout)
 {
-	char *line;
+	char line[256];
 	char *reply;
+	unsigned int i;
 	int ret;
+	char prompt[] = "multipathd> ";
 
 	cli_init();
-	rl_readline_name = "multipathd";
-	rl_completion_entry_function = key_generator;
-	while ((line = readline("multipathd> "))) {
+	for (i = 0; i < strlen(prompt); i++)
+		fputc(prompt[i], stdout);
+	while (fgets(line, 256, stdin)) {
 		size_t llen = strlen(line);
 
-		if (!llen) {
-			free(line);
+		if (!llen)
 			continue;
-		}
 
 		if (need_quit(line, llen))
 			break;
@@ -94,11 +93,9 @@ static void process(int fd, unsigned int timeout)
 
 		print_reply(reply);
 
-		if (line && *line)
-			add_history(line);
-
-		free(line);
 		free(reply);
+		for (i = 0; i < strlen(prompt); i++)
+			fputc(prompt[i], stdout);
 	}
 }
 


### PR DESCRIPTION
libreadline changed the license to be incompatible with multipath-tools
usage, so replace it with a simple fgets().

Fixes: Issue #36 
Signed-off-by: Hannes Reinecke <hare@suse.de>