### PR TITLE
Licensing fixes

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install --yes gcc
           gcc make pkg-config abigail-tools
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
-          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev
+          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
       - name: create ABI
         run: make -O -j$(grep -c ^processor /proc/cpuinfo) abi.tar.gz
       - name: save ABI

--- a/.github/workflows/build-and-unittest.yaml
+++ b/.github/workflows/build-and-unittest.yaml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install --yes gcc
           make perl-base pkg-config valgrind
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
-          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev
+          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
       - name: build
         run: make -O -j$(grep -c ^processor /proc/cpuinfo)
       - name: test
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install --yes gcc-10
           make perl-base pkg-config valgrind
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
-          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev
+          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
       - name: set CC
         run: echo CC=gcc-10 >> $GITHUB_ENV
       - name: build
@@ -85,7 +85,7 @@ jobs:
           sudo apt-get install --yes clang
           make perl-base pkg-config valgrind
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
-          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev
+          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
       - name: set CC
         run: echo CC=clang >> $GITHUB_ENV
       - name: build

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -15,7 +15,7 @@ jobs:
           sudo apt-get install --yes
           gcc make pkg-config
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
-          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev
+          libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
       - name: download coverity
         run: >
           curl -o cov-analysis-linux64.tar.gz

--- a/.github/workflows/foreign.yaml
+++ b/.github/workflows/foreign.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [buster]
+        os: [bullseye]
         arch: ['ppc64le', 'aarch64', 's390x']
     container: mwilck/multipath-build-${{ matrix.os }}-${{ matrix.arch }}
     steps:
@@ -44,7 +44,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [buster]
+        os: [bullseye]
         arch: ['ppc64le', 'aarch64', 's390x']
     steps:
       - name: get binaries

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -24,13 +24,24 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
       - name: build and test
+        if: ${{ matrix.os != 'jessie' }}
         run: make test
+      - name: build and test (jessie)
+        # On jessie, we use libreadline 5 (no licensing issue)
+        if: ${{ matrix.os == 'jessie' }}
+        run: make READLINE=libreadline test
       - name: clean
         run: make clean
       - name: clang
+        if: ${{ matrix.os != 'jessie' }}
         env:
           CC: clang
         run: make test
+      - name: clang (jessie)
+        if: ${{ matrix.os == 'jessie' }}
+        env:
+          CC: clang
+        run: make READLINE=libreadline test
 
   rolling:
     runs-on: ubuntu-20.04
@@ -58,12 +69,13 @@ jobs:
           libjson-c-dev
           liburcu-dev
           libcmocka-dev
+          libedit-dev
       - name: dependencies-alpine
         if: ${{ matrix.os == 'alpine' }}
         run: >
           apk add make gcc clang cmocka
           musl-dev lvm2-dev libaio-dev readline-dev ncurses-dev eudev-dev
-          userspace-rcu-dev json-c-dev cmocka-dev
+          userspace-rcu-dev json-c-dev cmocka-dev libedit-dev
       - name: dependencies-fedora
         if: ${{ matrix.os == 'fedora:rawhide' }}
         run: >
@@ -78,6 +90,7 @@ jobs:
           userspace-rcu-devel
           json-c-devel
           libcmocka-devel
+          libedit-devel
       - name: checkout
         uses: actions/checkout@v1
       - name: build and test

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -8,6 +8,11 @@
 #
 # Uncomment to disable dmevents polling support
 # ENABLE_DMEVENTS_POLL = 0
+#
+# Readline library to use, libedit or libreadline
+# Caution: Using libreadline may make the multipathd binary undistributable,
+# see https://github.com/opensvc/multipath-tools/issues/36
+READLINE = libedit
 
 # List of scsi device handler modules to load on boot, e.g.
 # SCSI_DH_MODULES_PRELOAD := scsi_dh_alua scsi_dh_rdac

--- a/libmultipath/strbuf.c
+++ b/libmultipath/strbuf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 SUSE LLC
- * SPDX-License-Identifier: GPL-2.0-only
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <inttypes.h>
 #include <stdint.h>

--- a/libmultipath/strbuf.h
+++ b/libmultipath/strbuf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 SUSE LLC
- * SPDX-License-Identifier: GPL-2.0-only
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #ifndef _STRBUF_H
 #define _STRBUF_H

--- a/multipathd/Makefile
+++ b/multipathd/Makefile
@@ -22,7 +22,16 @@ CFLAGS += $(BIN_CFLAGS)
 LDFLAGS += $(BIN_LDFLAGS)
 LIBDEPS += -L$(multipathdir) -lmultipath -L$(mpathpersistdir) -lmpathpersist \
 	   -L$(mpathcmddir) -lmpathcmd -ludev -ldl -lurcu -lpthread \
-	   -ldevmapper -lreadline
+	   -ldevmapper
+
+ifeq ($(READLINE),libedit)
+CPPFLAGS += -DUSE_LIBEDIT
+LIBDEPS += -ledit
+endif
+ifeq ($(READLINE),libreadline)
+CPPFLAGS += -DUSE_LIBREADLINE
+LIBDEPS += -lreadline
+endif
 
 ifdef SYSTEMD
 	CPPFLAGS += -DUSE_SYSTEMD=$(SYSTEMD)

--- a/multipathd/cli.c
+++ b/multipathd/cli.c
@@ -11,7 +11,12 @@
 #include "parser.h"
 #include "util.h"
 #include "version.h"
+#ifdef USE_LIBEDIT
+#include <editline/readline.h>
+#endif
+#ifdef USE_LIBREADLINE
 #include <readline/readline.h>
+#endif
 
 #include "mpath_cmd.h"
 #include "cli.h"

--- a/multipathd/uxclnt.c
+++ b/multipathd/uxclnt.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdarg.h>
+#include <ctype.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/ioctl.h>

--- a/multipathd/uxclnt.c
+++ b/multipathd/uxclnt.c
@@ -16,8 +16,14 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <poll.h>
+
+#ifdef USE_LIBEDIT
+#include <editline/readline.h>
+#endif
+#ifdef USE_LIBREADLINE
 #include <readline/readline.h>
 #include <readline/history.h>
+#endif
 
 #include "mpath_cmd.h"
 #include "uxsock.h"


### PR DESCRIPTION
I'm submitting this from a separate branch to keep it isolated from the technical patches in the `queue` branch. @cvaroqui, please merge ASAP.

Fixes #36.

This is a first set of patches for the GPL 2.0/3.0 issue.
1. The bad license identifier is fixed in the strbuf code (This patch needs no Reviewed-by:, I'm just changing the\nlicense on behalf of SUSE LLC as I'm the only author).
2. libreadline is replaced by libedit, following the suggestions\nfrom the Debian licensing team in #36.
 
Another, additional set of licensing-related patches has been submitted to dm-devel and will improve the situation further. I'm submitting here nonetheless because the basic fix should be applied quickly.

Bastian Germann (1):
      multipathd: Add missing ctype include

Martin Wilck (7):
      libmultipath: convert license of strbuf code to GPL-2.0+
      multipathd: replace libreadline with libedit
      github workflows: build-and-unittest.yaml: add libedit-dev
      github workflows: coverity.yaml: add libedit-dev
      github workflows: abi.yaml: add libedit-dev
      GitHub workflows: native.yaml: add libedit-dev, except for jessie
      GitHub workflows: foreign.yaml: switch to Debian 11 (bullseye)

