### PR TITLE
README.md: mention libreadline and libedit optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,17 @@ To get latest devel code:
 Building multipath-tools
 ========================
 
-Prerequisites: development packages of for `libdevmapper`, `libreadline`,
-`libaio`, `libudev`, `libjson-c`, `liburcu`, and `libsystemd`.
+Prerequisites: development packages of for `libdevmapper`, `libaio`, `libudev`,
+`libjson-c`, `liburcu`, and `libsystemd`.
 
-To build multipath-tools, type:
+To enable commandline history and TAB completion in the interactive mode *(which
+is entered with `multipathd -k` or `multipathc`)* you might also set `READLINE`
+make variable to `libedit` or `libreadline`, like `make READLINE=libreadline`.
+That requires a development package for the library you chose. Note that using
+libreadline may [make binary indistributable due to license
+incompatibility](https://github.com/opensvc/multipath-tools/issues/36).
+
+Then, build and install multipath-tools with:
 
     make
 	make DESTDIR="/my/target/dir" install


### PR DESCRIPTION
Commit:

    b7771447b "multipathd: replace libreadline with libedit"

replaced libreadline with libedit, however the README file wasn't updated. So update it.

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>