### PR TITLE
Fix symbol resolution issues

### DIFF
--- a/libmpathutil/globals.c
+++ b/libmpathutil/globals.c
@@ -2,10 +2,10 @@
 #include <libudev.h>
 #include "globals.h"
 
-struct config __attribute__((weak)) *get_multipath_config(void)
+struct config *get_multipath_config(void)
 {
 	return NULL;
 }
 
-void __attribute__((weak)) put_multipath_config(void *p __attribute__((unused)))
+void put_multipath_config(void *p __attribute__((unused)))
 {}

--- a/libmpathutil/globals.c
+++ b/libmpathutil/globals.c
@@ -2,7 +2,6 @@
 #include <libudev.h>
 #include "globals.h"
 
-struct udev __attribute__((weak)) *udev;
 struct config __attribute__((weak)) *get_multipath_config(void)
 {
 	return NULL;

--- a/libmpathutil/globals.h
+++ b/libmpathutil/globals.h
@@ -3,25 +3,6 @@
 
 struct config;
 
-/**
- * extern variable: udev
- *
- * A &struct udev instance used by libmultipath. libmultipath expects
- * a valid, initialized &struct udev in this variable.
- * An application can define this variable itself, in which case
- * the applications's instance will take precedence.
- * The application can initialize and destroy this variable by
- * calling libmultipath_init() and libmultipath_exit(), respectively,
- * whether or not it defines the variable itself.
- * An application can initialize udev with udev_new() before calling
- * libmultipath_init(), e.g. if it has to make libudev calls before
- * libmultipath calls. If an application wants to keep using the
- * udev variable after calling libmultipath_exit(), it should have taken
- * an additional reference on it beforehand. This is the case e.g.
- * after initializing udev with udev_new().
- */
-extern struct udev *udev;
-
 /*
  * libmultipath provides default implementations of
  * get_multipath_config() and put_multipath_config().

--- a/libmpathutil/libmpathutil.version
+++ b/libmpathutil/libmpathutil.version
@@ -31,6 +31,18 @@
  *   The new version inherits the previous ones.
  */
 
+/*
+ * Symbols exported by both libmpathutil and libmultipath
+ * libmpathutil exports just dummy symbols, intended to be overriden
+ * by those in libmultipath.
+ * CAUTION - the version in libmpathutil.version and libmultipath.version
+ * must be THE SAME, otherwise the overriding will fail!
+ */
+LIBMPATHCOMMON_1.0.0 {
+	get_multipath_config;
+	put_multipath_config;
+};
+
 /* symbols referenced by multipath and multipathd */
 LIBMULTIPATH_16.0.0 {
 global:
@@ -46,7 +58,6 @@ global:
 	free_scandir_result;
 	free_strvec;
 	get_monotonic_time;
-	get_multipath_config;
 	get_next_string;
 	get_strbuf_len;
 	get_strbuf_str;
@@ -59,7 +70,6 @@ global:
 	normalize_timespec;
 	print_strbuf;
 	pthread_cond_init_mono;
-	put_multipath_config;
 	recv_packet;
 	reset_strbuf;
 	send_packet;

--- a/libmpathutil/libmpathutil.version
+++ b/libmpathutil/libmpathutil.version
@@ -90,7 +90,6 @@ LIBMPATHUTIL_1.0 {
 	append_strbuf_quoted;
 	basenamecpy;
 	cleanup_free_ptr;
-	devt2devname;
 	filepresent;
 	find_keyword;
 	free_keywords;

--- a/libmpathutil/libmpathutil.version
+++ b/libmpathutil/libmpathutil.version
@@ -70,7 +70,6 @@ global:
 	timespeccmp;
 	timespecsub;
 	truncate_strbuf;
-	udev;
 	ux_socket_listen;
 	vector_alloc;
 	vector_alloc_slot;

--- a/libmpathutil/util.c
+++ b/libmpathutil/util.c
@@ -163,32 +163,6 @@ size_t strlcat(char * restrict dst, const char * restrict src, size_t size)
 	return bytes;
 }
 
-int devt2devname(char *devname, int devname_len, const char *devt)
-{
-	struct udev_device *u_dev;
-	const char * dev_name;
-	int r;
-
-	if (!devname || !devname_len || !devt)
-		return 1;
-
-	u_dev = udev_device_new_from_devnum(udev, 'b', parse_devt(devt));
-	if (!u_dev) {
-		condlog(0, "\"%s\": invalid major/minor numbers, not found in sysfs", devt);
-		return 1;
-	}
-
-	dev_name = udev_device_get_sysname(u_dev);
-	if (!dev_name) {
-		udev_device_unref(u_dev);
-		return 1;
-	}
-	r = strlcpy(devname, dev_name, devname_len);
-	udev_device_unref(u_dev);
-
-	return !(r < devname_len);
-}
-
 /* This function returns a pointer inside of the supplied pathname string.
  * If is_path_device is true, it may also modify the supplied string */
 char *convert_dev(char *name, int is_path_device)

--- a/libmpathutil/util.h
+++ b/libmpathutil/util.h
@@ -18,7 +18,6 @@ char *get_next_string(char **temp, const char *split_char);
 int get_word (const char * sentence, char ** word);
 size_t strlcpy(char * restrict dst, const char * restrict src, size_t size);
 size_t strlcat(char * restrict dst, const char * restrict src, size_t size);
-int devt2devname (char *, int, const char *);
 dev_t parse_devt(const char *dev_t);
 char *convert_dev(char *dev, int is_path_device);
 void setup_thread_attr(pthread_attr_t *attr, size_t stacksize, int detached);

--- a/libmultipath/libmultipath.version
+++ b/libmultipath/libmultipath.version
@@ -122,7 +122,6 @@ global:
 	libmp_dm_task_run;
 	libmp_put_multipath_config;
 	libmp_udev_set_sync_support;
-	libmp_verbosity;
 	libmultipath_exit;
 	libmultipath_init;
 	load_config;

--- a/libmultipath/libmultipath.version
+++ b/libmultipath/libmultipath.version
@@ -31,6 +31,18 @@
  *   The new version inherits the previous ones.
  */
 
+/*
+ * Symbols exported by both libmpathutil and libmultipath
+ * libmpathutil exports just dummy symbols, intended to be overriden
+ * by those in libmultipath.
+ * CAUTION - the version in libmpathutil.version and libmultipath.version
+ * must be THE SAME, otherwise the overriding will fail!
+ */
+LIBMPATHCOMMON_1.0.0 {
+	get_multipath_config;
+	put_multipath_config;
+};
+
 LIBMULTIPATH_17.0.0 {
 global:
 	/* symbols referenced by multipath and multipathd */
@@ -98,7 +110,6 @@ global:
 	free_multipathvec;
 	free_path;
 	free_pathvec;
-	get_multipath_config;
 	get_multipath_layout;
 	get_path_layout;
 	get_pgpolicy_id;
@@ -136,7 +147,6 @@ global:
 	print_all_paths;
 	print_foreign_topology;
 	_print_multipath_topology;
-	put_multipath_config;
 	reinstate_paths;
 	remember_wwid;
 	remove_map;

--- a/libmultipath/sysfs.h
+++ b/libmultipath/sysfs.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include "strbuf.h"
 
+int devt2devname (char *, int, const char *);
 ssize_t sysfs_attr_set_value(struct udev_device *dev, const char *attr_name,
 			     const char * value, size_t value_len);
 ssize_t sysfs_attr_get_value(struct udev_device *dev, const char *attr_name,

--- a/tests/devt.c
+++ b/tests/devt.c
@@ -19,6 +19,9 @@
 #include "util.h"
 #include "debug.h"
 
+struct path;
+#include "sysfs.h"
+
 #include "globals.c"
 
 static bool sys_dev_block_exists(void)


### PR DESCRIPTION
Hi @cvaroqui, hi @bmarzins,

This set  fixes #47. The problem analysis can be seen in #47, and in the description of 
6e8aec6. In short, if we use duplicate symbols in different shared objects, we need to keep
the versions of these symbols in sync, otherwise symbol lookup won't work as intended.

I've sent this via GitHub and not via `dm-devel` because it's really purely technical stuff that
matters only little for the ML, and because people who upgrade multipath-tools because of 
CVE-2022-41973 and CVE-2022-41974 will be looking here.

The solution for the problem is 3-fold:
 - the symbols `udev` and `libmpverbosity` aren't duplicated any more, but defined only in libmultipath and libmpathutil, respectively.
 - This leaves `get_multipath_config` and `put_multipath_config` as duplicate symbols. For these, we use a new ABI "version" `LIBMPATHCOMMON_1.0.0`, with comments that make it clear that the version of these symbols must be changed synchronously in the two libraries.

Martin Wilck (5):
      libmpathutil: move devt2devname() to libmultipath
      libmpathutil: remove udev symbol
      libmultipath: remove duplicate export of libmp_verbosity
      libmpathutil: remove `__attribute__((weak))`
      libmultipath/libmpathutil: use common ABI version for duplicate symbols

@xosevp for information.