### PR TITLE
libmultipath: fix 'show paths format' failure

### DIFF
--- a/libmultipath/print.c
+++ b/libmultipath/print.c
@@ -734,8 +734,12 @@ snprint_host_adapter (struct strbuf *buff, const struct path * pp)
 static int
 snprint_path_checker (struct strbuf *buff, const struct path * pp)
 {
-	const struct checker * c = &pp->checker;
-	return snprint_str(buff, checker_name(c));
+	const char * n = checker_name(&pp->checker);
+
+	if (n)
+		return snprint_str(buff, n);
+	else
+		return snprint_str(buff, "(null)");
 }
 
 static int


### PR DESCRIPTION
Prevent 'multipathd show paths format "%c"' from failing on orphan paths. For orphan paths the checker class isn't set, which caused snprint_path_checker() to fail which in turn caused 'show paths format' to fail when the format string contained "%c".