### PR TITLE
kpartx_id: Add missing 3rd option in kpartx_id usage

### DIFF
--- a/kpartx/kpartx_id
+++ b/kpartx/kpartx_id
@@ -28,7 +28,7 @@ MINOR=$2
 UUID=$3
 
 if [ -z "$MAJOR" -o -z "$MINOR" ]; then
-    echo "usage: $0 major minor"
+    echo "usage: $0 major minor UUID"
     exit 1;
 fi
 


### PR DESCRIPTION
This patch adds missing 3rd option in kpatx_id usage.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>