### PR TITLE
libmultipath: fix max_sectors_kb on adding path

### DIFF
--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -593,11 +593,12 @@ sysfs_set_max_sectors_kb(struct multipath *mpp, int is_reload)
 	ssize_t len;
 	int i, j, ret, err = 0;
 	struct udev_device *udd;
-	int max_sectors_kb;
+	int max_sectors_kb = mpp->max_sectors_kb;
 
-	if (mpp->max_sectors_kb == MAX_SECTORS_KB_UNDEF)
+	/* by default, do not initialize max_sectors_kb on the device */
+	if (max_sectors_kb == MAX_SECTORS_KB_UNDEF && !is_reload)
 		return 0;
-	max_sectors_kb = mpp->max_sectors_kb;
+	/* on reload, re-apply the user tuning on all the path devices */
 	if (is_reload) {
 		if (!has_dm_info(mpp) &&
 		    dm_get_info(mpp->alias, &mpp->dmi) != 0) {


### PR DESCRIPTION
A user can change the value of max_sectors_kb on the multipath device and its path devices.
So when a path is deleted and then re-added, its value will not be the same as the multipath device. In that case the IOs could be mis-sized.

This was originally hit on Lustre FS on:
https://jira.whamcloud.com/browse/LU-9551

On reload, this patch re-apply max_sectors_kb value of the multipath device on its path devices.