### PR TITLE
multipathd.service: add socket as dependency

### DIFF
--- a/multipathd/multipathd.service
+++ b/multipathd/multipathd.service
@@ -5,6 +5,7 @@ Before=local-fs-pre.target blk-availability.service shutdown.target
 Wants=systemd-udevd-kernel.socket
 After=systemd-udevd-kernel.socket
 After=multipathd.socket systemd-remount-fs.service
+Wants=multipathd.socket
 Before=initrd-cleanup.service
 DefaultDependencies=no
 Conflicts=shutdown.target


### PR DESCRIPTION
Add multipathd.socket as a weak dependency. Before this commit, systemd knows the start order (socket -> Service) due to the After=multipathd.socket but no explicit dependency is made. This solves the issue if a user attempts to start the socket after the service like so:

    systemctl stop multipathd.service multipathd.socket
    systemctl start multipathd.service multipathd.socket

An error will be noted in journalctl, and the socket will be left in an inactive state if you query it with systemctl status multipathd.socket.