### PR TITLE
libmpathutil: Remove parse_prkey symbol

### DIFF
--- a/libmpathutil/libmpathutil.version
+++ b/libmpathutil/libmpathutil.version
@@ -113,7 +113,6 @@ LIBMPATHUTIL_1.0 {
 	log_safe;
 	msort;
 	parse_devt;
-	parse_prkey;
 	process_file;
 	safe_write;
 	set_value;


### PR DESCRIPTION
It was wrongly listed in libmpathutil's version script when it was split off from libmultipath in commit 4e1f20cf93a2 ("libmultipath: split off libmpathutil"), but was never part of libmpathutil

LLD 17 failed to link libmpathutil due to this:
```
ld.lld: error: version script assignment of 'LIBMPATHUTIL_1.0' to symbol 'parse_prkey' failed: symbol not defined
```

Remove the `parse_prkey` symbol to fix this