### PR TITLE
Spelling

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -37,7 +37,7 @@ prefix		:=
 exec_prefix	:= $(prefix)
 # Prefix for non-essential libraries (libdmmp)
 usr_prefix	:= $(if $(prefix),$(prefix),/usr)
-# Prefix for configfuration files (multipath.conf)
+# Prefix for configuration files (multipath.conf)
 etc_prefix	:= $(prefix)
 # Where to install systemd-related files. systemd is usually installed under /usr
 # Note: systemd installations with "split-usr=true" use separate "prefixdir" and

--- a/libdmmp/docs/kernel-doc
+++ b/libdmmp/docs/kernel-doc
@@ -1934,7 +1934,7 @@ sub process_name($$) {
 sub process_body($$) {
     my $file = shift;
 
-    if (/$doc_sect/i) { # case insensitive for supported section names
+    if (/$doc_sect/i) { # case-insensitive for supported section names
 	$newsection = $1;
 	$newcontents = $2;
 

--- a/libmpathutil/libmpathutil.version
+++ b/libmpathutil/libmpathutil.version
@@ -20,7 +20,7 @@
  *   - externally visible data structures changed in incompatible ways
  *     (like offsets of previously existing struct members)
  *   In this case, the new version doesn't inherit the previous versions,
- *   because the new library doesn't provide the full previous ABI any more.
+ *   because the new library doesn't provide the full previous ABI anymore.
  *   All predecessors are merged into the new version.
  *
  * * Bump $MINOR for compatible changes, like adding symbols.

--- a/libmpathutil/log.c
+++ b/libmpathutil/log.c
@@ -149,7 +149,7 @@ static int _log_enqueue(int prio, const char * fmt, va_list ap)
 	if (la->head <= la->tail && len > (la->end - la->tail)) {
 		logdbg(stderr, "enqueue: rewind tail to %p\n", la->tail);
 		if (la->head == la->start ) {
-			logdbg(stderr, "enqueue: can not rewind tail, drop msg\n");
+			logdbg(stderr, "enqueue: cannot rewind tail, drop msg\n");
 			la->tail = lastmsg;
 			return 1;  /* can't reuse */
 		}

--- a/libmultipath/alias.c
+++ b/libmultipath/alias.c
@@ -560,7 +560,7 @@ static void read_bindings_file(void)
  *    bindings file fails.
  *  - if "alias_old" is set, it can't be bound to a different map. alias_old is
  *    initialized in find_existing_alias() by scanning the mpvec. We trust
- *    that the mpvec corrcectly represents kernel state.
+ *    that the mpvec correctly represents kernel state.
  */
 
 char *get_user_friendly_alias(const char *wwid, const char *alias_old,

--- a/libmultipath/alias.c
+++ b/libmultipath/alias.c
@@ -162,7 +162,7 @@ static const struct binding *get_binding_for_wwid(const Bindings *bindings,
  * This is achieved by sorting be length first, then using strcmp().
  * If multiple prefixes are in use, the aliases with a given prefix will
  * not necessarily be in a contiguous range of the vector, but they will
- * be ordered such that for a given prefix, numercally higher aliases will
+ * be ordered such that for a given prefix, numerically higher aliases will
  * always be sorted after lower ones.
  */
 static int alias_compar(const void *p1, const void *p2)

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -1097,7 +1097,7 @@ int coalesce_paths (struct vectors *vecs, vector mpvec, char *refwwid,
 	else
 		newmp = vector_alloc();
 	if (!newmp) {
-		condlog(0, "can not allocate newmp");
+		condlog(0, "cannot allocate newmp");
 		goto out;
 	}
 

--- a/libmultipath/devmapper.c
+++ b/libmultipath/devmapper.c
@@ -221,7 +221,7 @@ static int dm_tgt_version (unsigned int *version, char *str)
 
 	if (!libmp_dm_task_run(dmt)) {
 		dm_log_error(2, DM_DEVICE_LIST_VERSIONS, dmt);
-		condlog(0, "Can not communicate with kernel DM");
+		condlog(0, "Cannot communicate with kernel DM");
 		goto out;
 	}
 	target = dm_task_get_versions(dmt);

--- a/libmultipath/foreign/nvme.c
+++ b/libmultipath/foreign/nvme.c
@@ -410,7 +410,7 @@ void cleanup(struct context *ctx)
 	lock(ctx);
 	/*
 	 * Locking is not strictly necessary here, locking in foreign.c
-	 * makes sure that no other code is called with this ctx any more.
+	 * makes sure that no other code is called with this ctx anymore.
 	 * But this should make static checkers feel better.
 	 */
 	pthread_cleanup_push(unlock, ctx);

--- a/libmultipath/libmultipath.version
+++ b/libmultipath/libmultipath.version
@@ -20,7 +20,7 @@
  *   - externally visible data structures changed in incompatible ways
  *     (like offsets of previously existing struct members)
  *   In this case, the new version doesn't inherit the previous versions,
- *   because the new library doesn't provide the full previous ABI any more.
+ *   because the new library doesn't provide the full previous ABI anymore.
  *   All predecessors are merged into the new version.
  *
  * * Bump $MINOR for compatible changes, like adding symbols.

--- a/libmultipath/structs_vec.c
+++ b/libmultipath/structs_vec.c
@@ -215,7 +215,7 @@ static bool update_pathvec_from_dm(vector pathvec, struct multipath *mpp,
 				 * This path exists, but in the wrong map.
 				 * We can't reload the map from here.
 				 * Make sure it isn't used in this map
-				 * any more, and let the checker re-add
+				 * anymore, and let the checker re-add
 				 * it as it sees fit.
 				 */
 				dm_fail_path(mpp->alias, pp->dev_t);

--- a/libmultipath/sysfs.c
+++ b/libmultipath/sysfs.c
@@ -71,7 +71,7 @@ static ssize_t __sysfs_attr_get_value(struct udev_device *dev, const char *attr_
 	/* read attribute value */
 	fd = open(devpath, O_RDONLY);
 	if (fd < 0) {
-		condlog(3, "%s: attribute '%s' can not be opened: %s",
+		condlog(3, "%s: attribute '%s' cannot be opened: %s",
 			__func__, devpath, strerror(errno));
 		return -errno;
 	}
@@ -137,7 +137,7 @@ ssize_t sysfs_attr_set_value(struct udev_device *dev, const char *attr_name,
 	/* write attribute value */
 	fd = open(devpath, O_WRONLY);
 	if (fd < 0) {
-		condlog(3, "%s: attribute '%s' can not be opened: %s",
+		condlog(3, "%s: attribute '%s' cannot be opened: %s",
 			__func__, devpath, strerror(errno));
 		return -errno;
 	}

--- a/libmultipath/uevent.c
+++ b/libmultipath/uevent.c
@@ -250,7 +250,7 @@ merge_need_stop(struct uevent *earlier, struct uevent *later)
 		return true;
 
 	/*
-	 * we can not make a jugement without wwid,
+	 * we cannot make a jugement without wwid,
 	 * so it is sensible to stop merging
 	 */
 	if (!earlier->wwid || !later->wwid)

--- a/multipath/main.c
+++ b/multipath/main.c
@@ -469,7 +469,7 @@ configure (struct config *conf, enum mpath_cmds cmd,
 	newmp = vector_alloc();
 
 	if (!curmp || !pathvec || !newmp) {
-		condlog(0, "can not allocate memory");
+		condlog(0, "cannot allocate memory");
 		goto out;
 	}
 	vecs.pathvec = pathvec;

--- a/multipath/multipath.conf.5.in
+++ b/multipath/multipath.conf.5.in
@@ -96,7 +96,7 @@ not mandatory.
 .B Note on regular expressions:
 The \fI@CONFIGFILE@\fR syntax allows many attribute values to be specified as POSIX
 Extended Regular Expressions (see \fBregex\fR(7)). These regular expressions
-are \fBcase sensitive\fR and \fBnot anchored\fR, thus the expression "bar" matches "barbie",
+are \fBcase-sensitive\fR and \fBnot anchored\fR, thus the expression "bar" matches "barbie",
 "rhabarber", and "wunderbar", but not "Barbie". To avoid unwanted substring
 matches, standard regular expression syntax using the special characters "^" and "$" can be used.
 .

--- a/multipath/multipath.conf.5.in
+++ b/multipath/multipath.conf.5.in
@@ -308,7 +308,7 @@ The default is: \fB<unset>\fR. To enable uevent merging, set it e.g. to
 .B uid_attribute
 The udev attribute providing a unique path identifier (WWID). If
 \fIuid_attribute\fR is set to the empty string, WWID determination is done
-using the \fIsysfs\fR method rather then using udev (not recommended in
+using the \fIsysfs\fR method rather than using udev (not recommended in
 production; see \fBWWID generation\fR below).
 .RS
 .TP

--- a/multipath/multipath.conf.5.in
+++ b/multipath/multipath.conf.5.in
@@ -187,7 +187,7 @@ The default is: \fBno\fR
 .
 .TP
 .B multipath_dir
-(Deprecated) This option is not supported any more, and the value is ignored.
+(Deprecated) This option is not supported anymore, and the value is ignored.
 .
 .
 .TP
@@ -277,7 +277,7 @@ The default is: \fBno\fR
 .
 .TP
 .B pg_timeout
-(Deprecated) This option is not supported any more, and the value is ignored.
+(Deprecated) This option is not supported anymore, and the value is ignored.
 .
 .
 .TP
@@ -322,7 +322,7 @@ The default is: \fBID_WWN\fR, for NVMe devices
 .
 .TP
 .B getuid_callout
-(Deprecated) This option is not supported any more, and the value is ignored.
+(Deprecated) This option is not supported anymore, and the value is ignored.
 .
 .
 .TP
@@ -808,7 +808,7 @@ The default is: \fB<unset>\fR
 .
 .TP
 .B bindings_file
-(Deprecated) This option is not supported any more, and will be ignored.
+(Deprecated) This option is not supported anymore, and will be ignored.
 .RS
 .TP
 The compiled-in value is: \fB@STATE_DIR@/bindings\fR
@@ -817,7 +817,7 @@ The compiled-in value is: \fB@STATE_DIR@/bindings\fR
 .
 .TP
 .B wwids_file
-(Deprecated) This option is not supported any more, and will be ignored.
+(Deprecated) This option is not supported anymore, and will be ignored.
 .RS
 .TP
 The compiled-in value is: \fB@STATE_DIR@/wwids\fR
@@ -826,7 +826,7 @@ The compiled-in value is: \fB@STATE_DIR@/wwids\fR
 .
 .TP
 .B prkeys_file
-(Deprecated) This option is not supported any more, and will be ignored.
+(Deprecated) This option is not supported anymore, and will be ignored.
 .RS
 .TP
 The compiled-in value is: \fB@STATE_DIR@/prkeys\fR
@@ -995,7 +995,7 @@ The default is: \fB<unset>\fR
 .
 .TP
 .B config_dir
-(Deprecated) This option is not supported any more, and the value is ignored.
+(Deprecated) This option is not supported anymore, and the value is ignored.
 .RS
 .TP
 The compiled-in value is: \fB@CONFIGDIR@\fR
@@ -1293,7 +1293,7 @@ The default is: \fBno\fR
 .
 .TP
 .B disable_changed_wwids
-(Deprecated) This option is not supported any more, and the value is ignored.
+(Deprecated) This option is not supported anymore, and the value is ignored.
 .RE
 .
 .
@@ -1467,7 +1467,7 @@ The protocol that a path is using can be viewed by running
 For every device, these 5 blacklist criteria are evaluated in the order
 "property, dev\%node, device, protocol, wwid". If a device turns out to be
 blacklisted by any criterion, it's excluded from handling by multipathd, and
-the later criteria aren't evaluated any more. For each
+the later criteria aren't evaluated anymore. For each
 criterion, the whitelist takes precedence over the blacklist if a device
 matches both.
 .LP

--- a/multipath/multipath.rules.in
+++ b/multipath/multipath.rules.in
@@ -80,7 +80,7 @@ ENV{SYSTEMD_READY}="0"
 GOTO="end_mpath"
 
 LABEL="stop_wait"
-# If timeout hasn't expired but we're not in "maybe" state any more, stop timer
+# If timeout hasn't expired but we're not in "maybe" state anymore, stop timer
 # Do this only once, and only if the timer has been started before
 IMPORT{db}="FIND_MULTIPATHS_WAIT_CANCELLED"
 ENV{FIND_MULTIPATHS_WAIT_CANCELLED}=="?*", GOTO="end_mpath"

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -1113,7 +1113,7 @@ uev_add_path (struct uevent *uev, struct vectors * vecs, int need_do_map)
 					 * Failure in ev_remove_path will keep
 					 * path in pathvec in INIT_REMOVED state
 					 * Fail the path to make sure it isn't
-					 * used any more.
+					 * used anymore.
 					 */
 					pp->dmstate = PSTATE_FAILED;
 					dm_fail_path(pp->mpp->alias, pp->dev_t);
@@ -3323,7 +3323,7 @@ static void cleanup_threads(void)
 
 	/*
 	 * As all threads are joined now, and we're in DAEMON_SHUTDOWN
-	 * state, no new waiter threads will be created any more.
+	 * state, no new waiter threads will be created anymore.
 	 */
 	pthread_attr_destroy(&waiter_attr);
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,7 +64,7 @@ to wrap a function which is both defined in libmultipath and called from other
 functions in libmultipath, such as `checker_check()`. When `libmultipath.so` is
 created, the linker resolves calls to `checker_check()` inside the `.so`
 file. When later the test executable is built by linking the test object file with
-`libmultipath.so`, these calls can't be wrapped any more, because they've
+`libmultipath.so`, these calls can't be wrapped anymore, because they've
 already been resolved, and wrapping works only for *unresolved* symbols.
 Therefore, object files from libraries that contain calls to functions
 which need to be wrapped must be explicitly listed on the linker command line

--- a/tests/alias.c
+++ b/tests/alias.c
@@ -38,7 +38,7 @@ static int __set_errno(int err)
 
 /*
  * allocate_binding -> write_bindings_file() writes the entire file, i.e. the
- * header, any pre-existing bindings, and the new binding. The complete content
+ * header, any preexisting bindings, and the new binding. The complete content
  * depends on history and is different to predict here. Therefore we check only
  * the newly added binding. Because add_binding() sorts entries, this new
  * binding isn't necessarily the last one; receive it from will_return() and

--- a/tests/sysfs.c
+++ b/tests/sysfs.c
@@ -170,7 +170,7 @@ static void test_sagv_open_fail(void **state)
 	expect_value(__wrap_open, flags, O_RDONLY);
 	errno = ENOENT;
 	will_return(__wrap_open, -1);
-	expect_condlog(3, "__sysfs_attr_get_value: attribute '/foo/bar' can not be opened");
+	expect_condlog(3, "__sysfs_attr_get_value: attribute '/foo/bar' cannot be opened");
 	assert_int_equal(sysfs_attr_get_value((void *)state, "bar",
 					      buf, sizeof(buf)), -ENOENT);
 }
@@ -389,7 +389,7 @@ static void test_sasv_open_fail(void **state)
 	expect_value(__wrap_open, flags, O_WRONLY);
 	errno = EPERM;
 	will_return(__wrap_open, -1);
-	expect_condlog(3, "sysfs_attr_set_value: attribute '/foo/bar' can not be opened");
+	expect_condlog(3, "sysfs_attr_set_value: attribute '/foo/bar' cannot be opened");
 	assert_int_equal(sysfs_attr_set_value((void *)state, "bar",
 					      buf, sizeof(buf)), -EPERM);
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/opensvc/multipath-tools/pull/37

Fixes misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/multipath-tools/actions/runs/7405969189/attempts/1#summary-20149678198

The action will report that the changes in this PR would make it happy: https://github.com/jsoref/multipath-tools/actions/runs/7405969286/attempts/1#summary-20149678465