### PR TITLE
libmultipath: always use glibc basename()

### DIFF
--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -43,6 +43,19 @@
 #include "sysfs.h"
 #include "io_err_stat.h"
 
+#ifndef __GLIBC__
+/*
+ * glibc's non-destructive version of basename()
+ * License: LGPL-2.1-or-later
+ */
+static const char *__basename(const char *filename)
+{
+	char *p = strrchr(filename, '/');
+	return p ? p + 1 : filename;
+}
+#define basename(x) __basename(x)
+#endif
+
 /* group paths in pg by host adapter
  */
 int group_by_host_adapter(struct pathgroup *pgp, vector adapters)


### PR DESCRIPTION
There is a use of basename() which expects it to be GNU version of basename, which is not available in other libcs e.g. musl on Linux therefore provide a version for such cases