### PR TITLE
libmpathutil: explicitly annotate {get,put}_multipath_config as weak

### DIFF
--- a/libmpathutil/globals.c
+++ b/libmpathutil/globals.c
@@ -2,10 +2,10 @@
 #include <libudev.h>
 #include "globals.h"
 
-struct config *get_multipath_config(void)
+__attribute__((weak)) struct config *get_multipath_config(void)
 {
 	return NULL;
 }
 
-void put_multipath_config(void *p __attribute__((unused)))
+__attribute__((weak)) void put_multipath_config(void *p __attribute__((unused)))
 {}

--- a/libmultipath/config.c
+++ b/libmultipath/config.c
@@ -82,7 +82,7 @@ struct config *libmp_get_multipath_config(void)
 }
 
 struct config *get_multipath_config(void)
-	__attribute__((alias("libmp_get_multipath_config")));
+	__attribute__((weak, alias("libmp_get_multipath_config")));
 
 void libmp_put_multipath_config(void *conf __attribute__((unused)))
 {
@@ -90,7 +90,7 @@ void libmp_put_multipath_config(void *conf __attribute__((unused)))
 }
 
 void put_multipath_config(void *conf)
-	__attribute__((alias("libmp_put_multipath_config")));
+	__attribute__((weak, alias("libmp_put_multipath_config")));
 
 static int
 hwe_strmatch (const struct hwentry *hwe1, const struct hwentry *hwe2)


### PR DESCRIPTION
When linking libmpathutil with -Bsymbolic-non-weak-functions, multipathd segfaults because the weak nature of these symbols is not recognized.

Add the necessary attributes to make that clear to the linker.

Fixes: https://github.com/opensvc/multipath-tools/issues/26 # sort of
Tested-by: ns <0n-s@users.noreply.github.com>