### PR TITLE
multipath: display the correct configuration when dumpping config

### DIFF
--- a/multipath/main.c
+++ b/multipath/main.c
@@ -852,8 +852,6 @@ main (int argc, char *argv[])
 	if (atexit(uninit_config))
 		condlog(1, "failed to register cleanup handler for config: %m");
 	conf = get_multipath_config();
-	conf->retrigger_tries = 0;
-	conf->force_sync = 1;
 	if (atexit(cleanup_vecs))
 		condlog(1, "failed to register cleanup handler for vecs: %m");
 	if (atexit(cleanup_bindings))
@@ -999,6 +997,11 @@ main (int argc, char *argv[])
 	set_max_fds(conf->max_fds);
 
 	libmp_udev_set_sync_support(1);
+
+	if (cmd != CMD_DUMP_CONFIG) {
+		conf->retrigger_tries = 0;
+		conf->force_sync = 1;
+	}
 
 	if ((cmd == CMD_LIST_SHORT || cmd == CMD_LIST_LONG) && enable_foreign)
 		conf->enable_foreign = strdup("");


### PR DESCRIPTION
"multipath -t" and "multipath -T" might show the wrong multipathd configuration items "retrigger_tries" and "force_sync". Make sure they don't.

I've already sent this patch to the mailing list for multipath-tools(dm-devel@lists.linux.dev).
https://lore.kernel.org/dm-devel/tencent_FE02DEB8FF48DD9EE156F288BCE172E25709@qq.com