### PR TITLE
multipath-tools 0.11.1

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -11,6 +11,7 @@ ata
 autoconfig
 autodetected
 autoresize
+backported
 barbie
 BINDIR
 blkid
@@ -123,6 +124,7 @@ Lun
 lvm
 lvmteam
 Marzinski
+misdetection
 mpath
 mpathb
 mpathpersist

--- a/.github/workflows/abi-stable.yaml
+++ b/.github/workflows/abi-stable.yaml
@@ -15,12 +15,16 @@ on:
 
 jobs:
   reference-abi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: get parent tag
         run: >
           echo ${{ github.ref }} |
           sed -E 's,refs/heads/stable-([0-9]\.[0-9]*)\.y,PARENT_TAG=\1.0,' >> $GITHUB_ENV
+        if: ${{ github.event_name == 'push' }}
+      - name: get parent tag
+        run: echo PARENT_TAG=${{ github.base_ref }} >> $GITHUB_ENV
+        if: ${{ github.event_name == 'pull_request' }}
       - name: assert parent tag
         run: /bin/false
         if: ${{ env.PARENT_TAG == '' }}
@@ -45,20 +49,24 @@ jobs:
           path: abi
 
   check-abi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: reference-abi
     steps:
       - name: get parent tag
         run: >
           echo ${{ github.ref }} |
           sed -E 's,refs/heads/stable-([0-9]\.[0-9]*)\.y,PARENT_TAG=\1.0,' >> $GITHUB_ENV
+        if: ${{ github.event_name == 'push' }}
+      - name: get parent tag
+        run: echo PARENT_TAG=${{ github.base_ref }} >> $GITHUB_ENV
+        if: ${{ github.event_name == 'pull_request' }}
       - name: assert parent tag
         run: /bin/false
         if: ${{ env.PARENT_TAG == '' }}
-      - name: checkout ${{ env.PARENT_TAG }}
+      - name: checkout ${{ github.base_ref }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.PARENT_TAG }}
+          ref: ${{ github.base_ref }}
       - name: download ABI for ${{ env.PARENT_TAG }}
         id: download_abi
         uses: actions/download-artifact@v4

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,27 @@ release. These bug fixes will be tracked in stable branches.
 
 See [README.md](README.md) for additional information.
 
+## multipath-tools 0.11.1, 2025/02
+
+This release contains backported bug fixes from the master branch up to 0.12.
+
+### Bug fixes
+
+* Fix multipathd crash because of invalid path group index value, for example
+  if an invalid path device was removed from a map.
+  Fixes [#105](https://github.com/opensvc/multipath-tools/issues/105).
+* Make sure maps are reloaded in the path checker loop after detecting an
+  inconsistent or wrong kernel state (e.g. missing or falsely mapped path
+  device). Wrongly mapped paths will be unmapped and released to the system.
+  Fixes another issue reported in
+  [#105](https://github.com/opensvc/multipath-tools/issues/105).
+* Fix the problem that `group_by_tpg` might be disabled if one or more
+  paths were offline during initial configuration.
+* Fix possible misdetection of changed pathgroups in a map.
+* Fix the problem that if a map was scheduled to be reloaded already,
+  `max_sectors_kb` might not be set on a path device that
+  was being added to a multipath map. This problem was introduced in 0.9.9.
+
 ## multipath-tools 0.11.0, 2024/11
 
 ### User-visible changes

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -581,8 +581,6 @@ trigger_paths_udev_change(struct multipath *mpp, bool is_mpath)
 		vector_foreach_slot(pgp->paths, pp, j)
 			trigger_path_udev_change(pp, is_mpath);
 	}
-
-	mpp->needs_paths_uevent = 0;
 }
 
 static int sysfs_set_max_sectors_kb(struct multipath *mpp)
@@ -973,10 +971,10 @@ int domap(struct multipath *mpp, char *params, int is_daemon)
 		 * succeeded
 		 */
 		mpp->force_udev_reload = 0;
-		if (mpp->action == ACT_CREATE &&
-		    (remember_wwid(mpp->wwid) == 1 ||
-		     mpp->needs_paths_uevent))
+		if (mpp->action == ACT_CREATE) {
+			remember_wwid(mpp->wwid);
 			trigger_paths_udev_change(mpp, true);
+		}
 		if (!is_daemon) {
 			/* multipath client mode */
 			dm_switchgroup(mpp->alias, mpp->bestpg);
@@ -1001,8 +999,7 @@ int domap(struct multipath *mpp, char *params, int is_daemon)
 		}
 		dm_setgeometry(mpp);
 		return DOMAP_OK;
-	} else if (r == DOMAP_FAIL && mpp->action == ACT_CREATE &&
-		   mpp->needs_paths_uevent)
+	} else if (r == DOMAP_FAIL && mpp->action == ACT_CREATE)
 		trigger_paths_udev_change(mpp, false);
 
 	return DOMAP_FAIL;

--- a/libmultipath/devmapper.c
+++ b/libmultipath/devmapper.c
@@ -537,7 +537,7 @@ static uint16_t build_udev_flags(const struct multipath *mpp, int reload)
 		 MPATH_UDEV_RELOAD_FLAG : 0);
 }
 
-int dm_addmap_create (struct multipath *mpp, char * params)
+int dm_addmap_create (struct multipath *mpp, char *params)
 {
 	int ro;
 	uint16_t udev_flags = build_udev_flags(mpp, 0);
@@ -547,9 +547,7 @@ int dm_addmap_create (struct multipath *mpp, char * params)
 
 		if (dm_addmap(DM_DEVICE_CREATE, TGT_MPATH, mpp, params, ro,
 			      udev_flags)) {
-			if (unmark_failed_wwid(mpp->wwid) ==
-			    WWID_FAILED_CHANGED)
-				mpp->needs_paths_uevent = 1;
+			unmark_failed_wwid(mpp->wwid);
 			return 1;
 		}
 		/*
@@ -570,8 +568,7 @@ int dm_addmap_create (struct multipath *mpp, char * params)
 			break;
 		}
 	}
-	if (mark_failed_wwid(mpp->wwid) == WWID_FAILED_CHANGED)
-		mpp->needs_paths_uevent = 1;
+	mark_failed_wwid(mpp->wwid);
 	return 0;
 }
 

--- a/libmultipath/foreign.c
+++ b/libmultipath/foreign.c
@@ -129,7 +129,7 @@ static void free_pre(void *arg)
 static int _init_foreign(const char *enable)
 {
 	char pathbuf[PATH_MAX];
-	struct dirent **di;
+	struct dirent **di = NULL;
 	struct scandir_result sr;
 	int r, i;
 	regex_t *enable_re = NULL;

--- a/libmultipath/pgpolicies.c
+++ b/libmultipath/pgpolicies.c
@@ -127,6 +127,8 @@ fail:
 int group_paths(struct multipath *mp, int marginal_pathgroups)
 {
 	vector normal, marginal;
+	struct path *pp;
+	int i;
 
 	if (!mp->pg)
 		mp->pg = vector_alloc();
@@ -137,6 +139,10 @@ int group_paths(struct multipath *mp, int marginal_pathgroups)
 		goto out;
 	if (!mp->pgpolicyfn)
 		goto fail;
+
+	/* Reset pgindex, we're going to invalidate it */
+	vector_foreach_slot(mp->paths, pp, i)
+		pp->pgindex = 0;
 
 	if (!marginal_pathgroups ||
 	    split_marginal_paths(mp->paths, &normal, &marginal) != 0) {

--- a/libmultipath/propsel.c
+++ b/libmultipath/propsel.c
@@ -255,14 +255,18 @@ verify_alua_prio(struct multipath *mp)
 {
 	int i;
 	struct path *pp;
+	bool assume_alua = false;
 
 	vector_foreach_slot(mp->paths, pp, i) {
 		const char *name = prio_name(&pp->prio);
+		if (!prio_selected(&pp->prio))
+			continue;
 		if (strncmp(name, PRIO_ALUA, PRIO_NAME_LEN) &&
 		    strncmp(name, PRIO_SYSFS, PRIO_NAME_LEN))
 			 return false;
+		assume_alua = true;
 	}
-	return true;
+	return assume_alua;
 }
 
 int select_detect_pgpolicy(struct config *conf, struct multipath *mp)

--- a/libmultipath/structs.c
+++ b/libmultipath/structs.c
@@ -239,8 +239,18 @@ free_pgvec (vector pgvec, enum free_path_mode free_paths)
 	if (!pgvec)
 		return;
 
-	vector_foreach_slot(pgvec, pgp, i)
+	vector_foreach_slot(pgvec, pgp, i) {
+
+		/* paths are going to be re-grouped, reset pgindex */
+		if (free_paths != FREE_PATHS) {
+			struct path *pp;
+			int j;
+
+			vector_foreach_slot(pgp->paths, pp, j)
+				pp->pgindex = 0;
+		}
 		free_pathgroup(pgp, free_paths);
+	}
 
 	vector_free(pgvec);
 }

--- a/libmultipath/structs_vec.c
+++ b/libmultipath/structs_vec.c
@@ -349,8 +349,7 @@ int adopt_paths(vector pathvec, struct multipath *mpp,
 				 */
 				if (!current_mpp ||
 				    !mp_find_path_by_devt(current_mpp, pp->dev_t))
-					mpp->need_reload = mpp->need_reload ||
-						set_path_max_sectors_kb(pp, mpp->max_sectors_kb);
+					mpp->need_reload = set_path_max_sectors_kb(pp, mpp->max_sectors_kb) || mpp->need_reload;
 			}
 
 			pp->mpp = mpp;

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -794,8 +794,10 @@ coalesce_maps(struct vectors *vecs, vector nmpv)
 				vector_del_slot(ompv, i);
 				i--;
 			}
-			else
+			else {
 				condlog(2, "%s devmap removed", ompp->alias);
+				trigger_paths_udev_change(ompp, false);
+			}
 		} else if (reassign_maps) {
 			condlog(3, "%s: Reassign existing device-mapper"
 				" devices", ompp->alias);


### PR DESCRIPTION
## multipath-tools 0.11.1, 2025/02

This release contains backported bug fixes from the master branch up to 0.12.

### Bug fixes

* Fix multipathd crash because of invalid path group index value, for example
  if an invalid path device was removed from a map.
  Fixes [#105](https://github.com/opensvc/multipath-tools/issues/105).
* Make sure maps are reloaded in the path checker loop after detecting an
  inconsistent or wrong kernel state (e.g. missing or falsely mapped path
  device). Wrongly mapped paths will be unmapped and released to the system.
  Fixes another issue reported in
  [#105](https://github.com/opensvc/multipath-tools/issues/105).
* Fix the problem that `group_by_tpg` might be disabled if one or more
  paths were offline during initial configuration.
* Fix possible misdetection of changed pathgroups in a map.
* Fix the problem that if a map was scheduled to be reloaded already,
  `max_sectors_kb` might not be set on a path device that
  was being added to a multipath map. This problem was introduced in 0.9.9.
