### PR TITLE
Stable 0.10.3

### DIFF
--- a/.github/workflows/foreign.yaml
+++ b/.github/workflows/foreign.yaml
@@ -68,7 +68,9 @@ jobs:
       - name: unpack binary archive
         run: tar xfv test-progs.tar
       - name: enable foreign arch
-        uses: dbhi/qus/action@main
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
       - name: run tests
         uses: mosteo-actions/docker-run@v1
         with:
@@ -107,7 +109,9 @@ jobs:
       - name: unpack binary archive
         run: tar xfv test-progs.tar
       - name: enable foreign arch
-        uses: dbhi/qus/action@main
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
       - name: run tests
         uses: mosteo-actions/docker-run@v1
         with:

--- a/.github/workflows/multiarch-stable.yaml
+++ b/.github/workflows/multiarch-stable.yaml
@@ -46,7 +46,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: enable foreign arch
-        uses: dbhi/qus/action@main
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
       - name: compile and run unit tests
         uses: mosteo-actions/docker-run@v1
         with:

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -49,7 +49,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: enable foreign arch
-        uses: dbhi/qus/action@main
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
       - name: compile and run unit tests
         uses: mosteo-actions/docker-run@v1
         with:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -115,7 +115,7 @@ CPPFLAGS	:= $(FORTIFY_OPT) $(CPPFLAGS) $(D_URCU_VERSION) \
 		   -DRUNTIME_DIR=\"$(runtimedir)\" -DCONFIG_DIR=\"$(TGTDIR)$(configdir)\" \
 		   -DDEFAULT_CONFIGFILE=\"$(TGTDIR)$(configfile)\" -DSTATE_DIR=\"$(TGTDIR)$(statedir)\" \
 		   -DEXTRAVERSION=\"$(EXTRAVERSION)\" -MMD -MP
-CFLAGS		:= -std=gnu99 $(CFLAGS) $(OPTFLAGS) $(WARNFLAGS) -pipe \
+CFLAGS		:= -std=$(C_STD) $(CFLAGS) $(OPTFLAGS) $(WARNFLAGS) -pipe \
 		   -fexceptions
 BIN_CFLAGS	:= -fPIE -DPIE
 LIB_CFLAGS	:= -fPIC

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # multipath-tools Release Notes
 
+## multipath-tools 0.10.3, 2025/03
+
+This release fixes some compilation issues, and adds a hwtable entry.
+
 ## multipath-tools 0.10.2, 2025/02
 
 This release contains backported bug fixes from the stable-0.11.y branch.

--- a/create-config.mk
+++ b/create-config.mk
@@ -157,6 +157,18 @@ FORTIFY_OPT := $(shell \
 		echo "-D_FORTIFY_SOURCE=2"; \
 	fi)
 
+# Check is you can compile with the urcu.h header, using the C99 standard.
+# If urcu/config-<arch>.h defines CONFIG_RCU_USE_ATOMIC_BUILTINS, then anything
+# including urcu.h must be compiled with at least the C11 standard. See:
+# https://github.com/urcu/userspace-rcu/commit/89280d020bf064d1055c360fb9974f128051043f
+C_STD := $(shell \
+	if printf '$(__HASH__)include <urcu.h>\nint main(void) { return 0; }\n' | $(CC) -o /dev/null -c -xc --std=gnu99 - 2>/dev/null; \
+	then \
+		echo "gnu99"; \
+	else \
+		echo "gnu11"; \
+	fi)
+
 STACKPROT :=
 
 all:	$(TOPDIR)/config.mk
@@ -182,3 +194,4 @@ $(TOPDIR)/config.mk:	$(multipathdir)/autoconfig.h
 	@echo "W_MISSING_INITIALIZERS := $(call TEST_MISSING_INITIALIZERS)" >>$@
 	@echo "W_URCU_TYPE_LIMITS := $(call TEST_URCU_TYPE_LIMITS)" >>$@
 	@echo "ENABLE_LIBDMMP := $(ENABLE_LIBDMMP)" >>$@
+	@echo "C_STD := $(C_STD)" >>$@

--- a/libmpathutil/uxsock.c
+++ b/libmpathutil/uxsock.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdarg.h>
+#include <string.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>

--- a/libmultipath/checkers/tur.c
+++ b/libmultipath/checkers/tur.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <sys/time.h>
 #include <pthread.h>
+#include <urcu.h>
 #include <urcu/uatomic.h>
 
 #include "checkers.h"

--- a/libmultipath/hwtable.c
+++ b/libmultipath/hwtable.c
@@ -190,9 +190,9 @@ static struct hwentry default_hw[] = {
 		.prio_name     = PRIO_ALUA,
 	},
 	{
-		/* MSA 1040, 1050, 1060, 2040, 2050 and 2060 families */
+		/* MSA 1040, 1050, 1060, 2040, 2050, 2060 and 2070 families */
 		.vendor        = "(HP|HPE)",
-		.product       = "MSA [12]0[456]0 (SAN|SAS|FC|iSCSI)",
+		.product       = "MSA [12]0[4567]0 (SAN|SAS|FC|iSCSI)",
 		.pgpolicy      = GROUP_BY_PRIO,
 		.pgfailback    = -FAILBACK_IMMEDIATE,
 		.no_path_retry = 18,

--- a/libmultipath/lock.h
+++ b/libmultipath/lock.h
@@ -2,6 +2,7 @@
 #define LOCK_H_INCLUDED
 
 #include <pthread.h>
+#include <urcu.h>
 #include <urcu/uatomic.h>
 #include <stdbool.h>
 

--- a/libmultipath/version.h
+++ b/libmultipath/version.h
@@ -20,9 +20,9 @@
 #ifndef VERSION_H_INCLUDED
 #define VERSION_H_INCLUDED
 
-#define VERSION_CODE 0x000A02
+#define VERSION_CODE 0x000A03
 /* MMDDYY, in hex */
-#define DATE_CODE    0x011819
+#define DATE_CODE    0x070e19
 
 #define PROG    "multipath-tools"
 


### PR DESCRIPTION
Includes backports of d9c6133 ("multipathd: trigger uevents for blacklisted paths in reconfigure") and c0cf3cb ("multipath-tools: add HPE MSA Gen7 (2070/2072) to hwtable"), and some minor compilation related fixes.