### PR TITLE
multipath-tools test: add missing include for stdint.h

### DIFF
--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <cmocka.h>
 #include "log.h"


### PR DESCRIPTION
When building multipath-tools with cmocka 1.1.8. it produces following error when `make test`:
```
2025-07-18 14:42:21 In file included from test-log.c:6:
2025-07-18 14:42:21 test-log.c: In function '__wrap_dlog':
2025-07-18 14:42:21 test-log.c:24:20: error: 'uintptr_t' undeclared (first use in this function)
2025-07-18 14:42:21    24 |         expected = mock_ptr_type(char *);
2025-07-18 14:42:21       |                    ^~~~~~~~~~~~~
2025-07-18 14:42:21 test-log.c:10:1: note: 'uintptr_t' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
2025-07-18 14:42:21     9 | #include "debug.h"
2025-07-18 14:42:21   +++ |+#include <stdint.h>
2025-07-18 14:42:21    10 | 
2025-07-18 14:42:21 test-log.c:24:20: note: each undeclared identifier is reported only once for each function it appears in
2025-07-18 14:42:21    24 |         expected = mock_ptr_type(char *);
2025-07-18 14:42:21       |                    ^~~~~~~~~~~~~
2025-07-18 14:42:21 test-log.c:24:20: error: expected ')' before '_mock'
2025-07-18 14:42:21    24 |         expected = mock_ptr_type(char *);
2025-07-18 14:42:21       |                    ^~~~~~~~~~~~~
2025-07-18 14:42:21 test-log.c:24:20: note: to match this '('
2025-07-18 14:42:21    24 |         expected = mock_ptr_type(char *);
2025-07-18 14:42:21       |                    ^~~~~~~~~~~~~
2025-07-18 14:42:21 make[1]: *** [Makefile:74: test-log.o] Error 1
2025-07-18 14:42:21 rm parser.o.wrap dmevents.o.wrap hwtable.o.wrap uevent.o.wrap blacklist.o.wrap util.o.wrap
2025-07-18 14:42:21 make[1]: Leaving directory '/home/lkp/rpmbuild/BUILD/multipath-tools-0.9.5/tests'
2025-07-18 14:42:21 make: *** [Makefile:121: test] Error 2
2025-07-18 14:42:21 error: Bad exit status from /var/tmp/rpm-tmp.7qc9Bd (%check)
```

The attached patch fixed this issue.