### PR TITLE
multipath-tools 0.10.6

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -6,6 +6,7 @@ alloc
 alltgpt
 alua
 aptpl
+ASAN
 ascq
 ata
 autoconfig
@@ -76,6 +77,7 @@ getrlimit
 getuid
 github
 gitlab
+google
 GPT
 hbtl
 hds
@@ -191,6 +193,8 @@ rpmbuild
 rport
 rtpi
 rtprio
+sanitizer
+sanitizers
 sas
 sbp
 scsi

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -15,6 +15,7 @@ autoresize
 backported
 barbie
 BINDIR
+bitfield
 blkid
 bmarzins
 Bsymbolic
@@ -51,6 +52,7 @@ DIO
 directio
 disablequeueing
 dmevent
+dmi
 dmmp
 dmraid
 dmsetup
@@ -60,12 +62,14 @@ ECKD
 emc
 Engenio
 EVPD
+Exos
 failback
 failover
 fds
 fexceptions
 FFFFFFFF
 fge
+fno
 followover
 forcequeueing
 fpin
@@ -123,6 +127,7 @@ libudevdir
 liburcu
 linux
 LIO
+lld
 lpthread
 Lun
 lvm
@@ -142,12 +147,13 @@ multipathing
 multipaths
 multiqueue
 mwilck
+NFINIDAT
 NOLOG
 nompath
 NOSCAN
 Nosync
 nvme
-NFINIDAT
+Nytro
 OBJDEPS
 oneshot
 ontap
@@ -157,8 +163,10 @@ OPTFLAGS
 paramp
 partx
 pathgroup
+pathlist
 petabytes
 pgpolicy
+pgvec
 plugindir
 PNR
 ppc
@@ -193,14 +201,12 @@ rpmbuild
 rport
 rtpi
 rtprio
-sanitizer
 sanitizers
 sas
 sbp
 scsi
 SCST
 sda
-sdc
 Seagate
 setmarginal
 setprkey
@@ -255,6 +261,7 @@ usr
 uuid
 valgrind
 varoqui
+versioning
 Vess
 vgr
 VNX
@@ -265,6 +272,7 @@ weightedpath
 wholedisk
 Wilck
 wildcards
+Wno
 workflows
 wrt
 wwid

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -10,6 +10,11 @@
 #commit
 \b[0-9a-f]{7}\b
 
+# Generic Hex numbers
+\b0x[0-9a-f]{4}\b
+\b0x[0-9a-f]{8}\b
+\b0x[0-9a-f]{16}\b
+
 # WWNN/WWPN (NAA identifiers)
 \b(?:0x)?10[0-9a-f]{14}\b
 \b(?:0x|3)?[25][0-9a-f]{15}\b

--- a/.github/workflows/abi-stable.yaml
+++ b/.github/workflows/abi-stable.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   reference-abi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: get parent tag (push)
         run: >
@@ -51,7 +51,7 @@ jobs:
           path: abi
 
   check-abi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: reference-abi
     steps:
       - name: get parent tag (push)

--- a/.github/workflows/abi-stable.yaml
+++ b/.github/workflows/abi-stable.yaml
@@ -38,6 +38,7 @@ jobs:
           gcc make pkg-config abigail-tools
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
           libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
+          libmount-dev
       - name: checkout ${{ env.PARENT_TAG }}
         uses: actions/checkout@v4
         with:
@@ -86,6 +87,7 @@ jobs:
           gcc make pkg-config abigail-tools
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
           libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
+          libmount-dev
       - name: check ABI of ${{ github.ref }} against ${{ env.PARENT_TAG }}
         id: check_abi
         run: make -j$(nproc) -Orecurse abi-test

--- a/.github/workflows/abi-stable.yaml
+++ b/.github/workflows/abi-stable.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ env.PARENT_TAG }}
       - name: build ABI for ${{ env.PARENT_TAG }}
-        run: make -j$(grep -c ^processor /proc/cpuinfo) -Orecurse abi
+        run: make -j$(nproc) -Orecurse abi
       - name: save ABI
         uses: actions/upload-artifact@v4
         with:
@@ -88,7 +88,7 @@ jobs:
           libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
       - name: check ABI of ${{ github.ref }} against ${{ env.PARENT_TAG }}
         id: check_abi
-        run: make -j$(grep -c ^processor /proc/cpuinfo) -Orecurse abi-test
+        run: make -j$(nproc) -Orecurse abi-test
         continue-on-error: true
       - name: save differences
         if: ${{ steps.check_abi.outcome != 'success' }}

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -44,7 +44,7 @@ jobs:
           libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
           libmount-dev
       - name: create ABI
-        run: make -Orecurse -j$(grep -c ^processor /proc/cpuinfo) abi.tar.gz
+        run: make -Orecurse -j$(nproc) abi.tar.gz
       - name: save ABI
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ env.ABI_BRANCH == '' }}
         run: echo "ABI_BRANCH=master" >> $GITHUB_ENV
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: get reference ABI
         id: reference
         continue-on-error: true

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   save-and-test-ABI:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: set ABI branch
         if: ${{ env.ABI_BRANCH == '' }}
@@ -42,6 +42,7 @@ jobs:
           gcc make pkg-config abigail-tools
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
           libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
+          libmount-dev
       - name: create ABI
         run: make -Orecurse -j$(grep -c ^processor /proc/cpuinfo) abi.tar.gz
       - name: save ABI

--- a/.github/workflows/build-and-unittest.yaml
+++ b/.github/workflows/build-and-unittest.yaml
@@ -20,7 +20,7 @@ jobs:
         rl: ['', 'libreadline', 'libedit']
         cc: [ gcc, clang ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: update
         run: sudo apt-get update
       - name: dependencies
@@ -75,7 +75,7 @@ jobs:
         rl: ['', 'libreadline', 'libedit']
         cc: [ gcc, clang ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: mpath
         run: sudo modprobe dm_multipath
       - name: brd

--- a/.github/workflows/build-and-unittest.yaml
+++ b/.github/workflows/build-and-unittest.yaml
@@ -13,7 +13,7 @@ on:
       - 'stable-*'
 jobs:
   jammy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-unittest.yaml
+++ b/.github/workflows/build-and-unittest.yaml
@@ -46,16 +46,16 @@ jobs:
         if: ${{ matrix.cc == 'clang' }}
       - name: build
         run: >
-          make -Orecurse -j$(grep -c ^processor /proc/cpuinfo)
+          make -Orecurse -j$(nproc)
           READLINE=${{ matrix.rl }} OPTFLAGS="$OPT"
       - name: test
         run: >
-          make -Orecurse -j$(grep -c ^processor /proc/cpuinfo)
+          make -Orecurse -j$(nproc)
           OPTFLAGS="$OPT" test
       - name: valgrind-test
         id: valgrind
         run: >
-          make -Orecurse -j$(grep -c ^processor /proc/cpuinfo)
+          make -Orecurse -j$(nproc)
           OPTFLAGS="$OPT" valgrind-test
         continue-on-error: true
       - name: valgrind-results
@@ -92,12 +92,12 @@ jobs:
       - name: set CC
         run: echo CC=${{ matrix.cc }} >> $GITHUB_ENV
       - name: build
-        run: make -Orecurse -j$(grep -c ^processor /proc/cpuinfo) READLINE=${{ matrix.rl }}
+        run: make -Orecurse -j$(nproc) READLINE=${{ matrix.rl }}
       - name: test
-        run: make -Orecurse -j$(grep -c ^processor /proc/cpuinfo) test
+        run: make -Orecurse -j$(nproc) test
       - name: valgrind-test
         id: valgrind
-        run: make -Orecurse -j$(grep -c ^processor /proc/cpuinfo) valgrind-test
+        run: make -Orecurse -j$(nproc) valgrind-test
         continue-on-error: true
       - name: valgrind-results
         run: cat tests/*.vgr

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -16,6 +16,7 @@ jobs:
           gcc make pkg-config
           libdevmapper-dev libreadline-dev libaio-dev libsystemd-dev
           libudev-dev libjson-c-dev liburcu-dev libcmocka-dev libedit-dev
+          libmount-dev
       - name: download coverity
         run: >
           curl -o cov-analysis-linux64.tar.gz

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: build with cov-build
         run: >
           PATH="$PWD/coverity/bin:$PATH"
-          cov-build --dir cov-int make -Orecurse -j"$(grep -c ^processor /proc/cpuinfo)"
+          cov-build --dir cov-int make -Orecurse -j"$(nproc)"
       - name: pack results
         run: tar cfz multipath-tools.tgz cov-int
       - name: submit results

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   upload-coverity-scan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: dependencies
         run: >
           sudo apt-get install --yes

--- a/.github/workflows/foreign.yaml
+++ b/.github/workflows/foreign.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
 
   cross-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
           overwrite: true
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: cross-build
     strategy:
       fail-fast: false
@@ -94,7 +94,7 @@ jobs:
           pull-params: "--platform linux/${{ env.CONTAINER_ARCH }}"
 
   root-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: cross-build
     strategy:
       fail-fast: false

--- a/.github/workflows/foreign.yaml
+++ b/.github/workflows/foreign.yaml
@@ -41,7 +41,7 @@ jobs:
     container: ghcr.io/mwilck/multipath-cross-debian_cross-${{ matrix.os }}-${{ matrix.arch }}
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: build
         run: make -j$(nproc) -Orecurse test-progs.tar
       - name: upload binary archive

--- a/.github/workflows/foreign.yaml
+++ b/.github/workflows/foreign.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
       - name: build
-        run: make -j -Orecurse test-progs.tar
+        run: make -j$(nproc) -Orecurse test-progs.tar
       - name: upload binary archive
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/multiarch-stable.yaml
+++ b/.github/workflows/multiarch-stable.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
 
   build-old:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multiarch-stable.yaml
+++ b/.github/workflows/multiarch-stable.yaml
@@ -38,13 +38,9 @@ jobs:
         arch: [386, arm/v7]
         include:
           - os: debian-trixie
-            arch: aarch64
-          - os: debian-trixie
             arch: s390x
           - os: debian-trixie
             arch: ppc64le
-          - os: debian-bookworm
-            arch: aarch64
           - os: debian-bookworm
             arch: s390x
           - os: debian-bookworm

--- a/.github/workflows/multiarch-stable.yaml
+++ b/.github/workflows/multiarch-stable.yaml
@@ -47,7 +47,7 @@ jobs:
             arch: ppc64le
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: enable foreign arch
         uses: docker/setup-qemu-action@v2
         with:

--- a/.github/workflows/multiarch-stable.yaml
+++ b/.github/workflows/multiarch-stable.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           image: tonistiigi/binfmt:latest
       - name: compile and run unit tests
+        id: test
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
@@ -61,3 +62,23 @@ jobs:
           command: test
           params: "--platform linux/${{ matrix.arch }}"
           pull-params: "--platform linux/${{ matrix.arch }}"
+        continue-on-error: true
+      - name: create binary archive
+        uses: mosteo-actions/docker-run@v1
+        with:
+          image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
+          guest-dir: /build
+          host-dir: ${{ github.workspace }}
+          command: test-progs.tar
+          params: "--platform linux/${{ matrix.arch }}"
+          pull-params: "--platform linux/${{ matrix.arch }}"
+        if: steps.test.outcome != 'success'
+      - name: upload binary archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.os }}-${{ matrix.arch }}
+          path: test-progs.tar
+        if: steps.test.outcome != 'success'
+      - name: fail
+        run: /bin/false
+        if: steps.test.outcome != 'success'

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -50,7 +50,7 @@ jobs:
             arch: aarch64
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: enable foreign arch
         uses: docker/setup-qemu-action@v2
         with:

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -30,7 +30,7 @@ on:
 jobs:
 
   build-current:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -39,12 +39,15 @@ jobs:
           - debian-sid
           - fedora-rawhide
           - opensuse-tumbleweed
-        arch: [amd64, ppc64le, aarch64, s390x, 386, arm/v7]
+        arch: [ppc64le, s390x, 386, arm/v7]
         exclude:
           - os: fedora-rawhide
             arch: 386
           - os: fedora-rawhide
             arch: arm/v7
+        include:
+          - os: alpine
+            arch: aarch64
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -56,6 +56,7 @@ jobs:
         with:
           image: tonistiigi/binfmt:latest
       - name: compile and run unit tests
+        id: test
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
@@ -64,4 +65,23 @@ jobs:
           command: test
           params: "--platform linux/${{ matrix.arch }}"
           pull-params: "--platform linux/${{ matrix.arch }}"
-
+        continue-on-error: true
+      - name: create binary archive
+        uses: mosteo-actions/docker-run@v1
+        with:
+          image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
+          guest-dir: /build
+          host-dir: ${{ github.workspace }}
+          command: test-progs.tar
+          params: "--platform linux/${{ matrix.arch }}"
+          pull-params: "--platform linux/${{ matrix.arch }}"
+        if: steps.test.outcome != 'success'
+      - name: upload binary archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.os }}-${{ matrix.arch }}
+          path: test-progs.tar
+        if: steps.test.outcome != 'success'
+      - name: fail
+        run: /bin/false
+        if: steps.test.outcome != 'success'

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -157,7 +157,6 @@ jobs:
         continue-on-error: true
 
       - name: create ${{ env.ARCHIVE_TGT }}
-        if: ${{ matrix.os != 'debian-jessie' }}
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
@@ -168,7 +167,6 @@ jobs:
               ( matrix.os != 'debian-jessie' &&
                 steps.test.outcome != 'success' ) }}
       - name: create ${{ env.ARCHIVE_TGT }} (jessie)
-        if: ${{ matrix.os == 'debian-jessie' }}
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
-          command: -j -Orecurse test
+          command: -j$(nproc) -Orecurse test
         continue-on-error: true
 
       - name: build and test (jessie)
@@ -72,7 +72,7 @@ jobs:
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
-          command: -j -Orecurse READLINE=libreadline test
+          command: -j$(nproc) -Orecurse READLINE=libreadline test
         continue-on-error: true
 
       - name: create ${{ env.ARCHIVE_TGT }}
@@ -144,7 +144,7 @@ jobs:
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
           params: -e CC=clang
-          command: -j -Orecurse test
+          command: -j$(nproc) -Orecurse test
         continue-on-error: true
       - name: clang (jessie)
         id: test_jessie
@@ -153,7 +153,7 @@ jobs:
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
           params: -e CC=clang
-          command: -j -Orecurse READLINE=libreadline test
+          command: -j$(nproc) -Orecurse READLINE=libreadline test
         continue-on-error: true
 
       - name: create ${{ env.ARCHIVE_TGT }}

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -37,7 +37,8 @@ jobs:
           - debian-bookworm
           - debian-trixie
           - fedora-43
-          - opensuse-leap
+          - opensuse-leap-15.6
+          - opensuse-leap-16.0
     steps:
       - name: checkout
         uses: actions/checkout@v1
@@ -45,10 +46,10 @@ jobs:
       - name: set archive name
         # Leap containers have cpio but not tar
         run: echo ARCHIVE_TGT=test-progs.cpio >> $GITHUB_ENV
-        if: ${{ matrix.os == 'opensuse-leap' }}
+        if: ${{ startswith(matrix.os, 'opensuse-leap-15') }}
       - name: set archive name
         run: echo ARCHIVE_TGT=test-progs.tar >> $GITHUB_ENV
-        if: ${{ matrix.os != 'opensuse-leap' }}
+        if: ${{ !startswith(matrix.os, 'opensuse-leap-15') }}
 
       - name: build and test
         if: ${{ matrix.os != 'debian-jessie' }}
@@ -96,7 +97,8 @@ jobs:
           - debian-bookworm
           - debian-trixie
           - fedora-43
-          - opensuse-leap
+          - opensuse-leap-15.6
+          - opensuse-leap-16.0
     steps:
       - name: checkout
         uses: actions/checkout@v1
@@ -129,7 +131,8 @@ jobs:
           - debian-bookworm
           - debian-trixie
           - fedora-43
-          - opensuse-leap
+          - opensuse-leap-15.6
+          - opensuse-leap-16.0
     steps:
       - name: mpath
         run: sudo modprobe dm_multipath
@@ -145,10 +148,10 @@ jobs:
           name: native-${{ matrix.os }}
       - name: unpack binary archive
         run: cpio -idv < test-progs.cpio
-        if: ${{ matrix.os == 'opensuse-leap' }}
+        if: ${{ startswith(matrix.os, 'opensuse-leap-15') }}
       - name: unpack binary archive
         run: tar xfmv test-progs.tar
-        if: ${{ matrix.os != 'opensuse-leap' }}
+        if: ${{ !startswith(matrix.os, 'opensuse-leap-15') }}
 
       - name: run root tests
         uses: mosteo-actions/docker-run@v1

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -36,7 +36,7 @@ jobs:
           - debian-bullseye
           - debian-bookworm
           - debian-trixie
-          - fedora-42
+          - fedora-43
           - opensuse-leap
     steps:
       - name: checkout
@@ -95,7 +95,7 @@ jobs:
           - debian-bullseye
           - debian-bookworm
           - debian-trixie
-          - fedora-42
+          - fedora-43
           - opensuse-leap
     steps:
       - name: checkout
@@ -128,7 +128,7 @@ jobs:
           - debian-bullseye
           - debian-bookworm
           - debian-trixie
-          - fedora-42
+          - fedora-43
           - opensuse-leap
     steps:
       - name: mpath

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.variant.runner }}
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: set archive name
         # Leap containers have cpio but not tar
@@ -127,7 +127,7 @@ jobs:
     runs-on: ${{ matrix.variant.runner }}
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: set archive name
         # Leap containers have cpio but not tar
@@ -224,7 +224,7 @@ jobs:
         run: sudo modprobe brd rd_nr=1 rd_size=65536
 
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: download binary archive
         uses: actions/download-artifact@v4

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   stable:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
           overwrite: true
 
   clang:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
           command: -j -Orecurse READLINE=libreadline test
 
   root-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: stable
     strategy:
       fail-fast: false

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -57,18 +57,23 @@ jobs:
         if: ${{ !startswith(matrix.os, 'opensuse-leap-15') }}
 
       - name: build and test
+        id: test
         if: ${{ matrix.os != 'debian-jessie' }}
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
           command: -j -Orecurse test
+        continue-on-error: true
+
       - name: build and test (jessie)
+        id: test_jessie
         # On jessie, we use libreadline 5 (no licensing issue)
         if: ${{ matrix.os == 'debian-jessie' }}
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
           command: -j -Orecurse READLINE=libreadline test
+        continue-on-error: true
 
       - name: create ${{ env.ARCHIVE_TGT }}
         if: ${{ matrix.os != 'debian-jessie' }}
@@ -90,6 +95,13 @@ jobs:
           path: ${{ env.ARCHIVE_TGT }}
           overwrite: true
 
+      - name: fail
+        run: /bin/false
+        if: >-
+          ${{ ( matrix.os == 'debian-jessie' &&
+                steps.test_jessie.outcome != 'success' ) ||
+              ( matrix.os != 'debian-jessie' &&
+                steps.test.outcome != 'success' ) }}
   clang:
     strategy:
       fail-fast: false
@@ -117,20 +129,75 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: set archive name
+        # Leap containers have cpio but not tar
+        run: echo ARCHIVE_TGT=test-progs.cpio >> $GITHUB_ENV
+        if: ${{ startswith(matrix.os, 'opensuse-leap-15') }}
+      - name: set archive name
+        run: echo ARCHIVE_TGT=test-progs.tar >> $GITHUB_ENV
+        if: ${{ !startswith(matrix.os, 'opensuse-leap-15') }}
+
       - name: clang
+        id: test
         if: ${{ matrix.os != 'debian-jessie' }}
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
           params: -e CC=clang
           command: -j -Orecurse test
+        continue-on-error: true
       - name: clang (jessie)
+        id: test_jessie
         if: ${{ matrix.os == 'debian-jessie' }}
         uses: mosteo-actions/docker-run@v1
         with:
           image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
           params: -e CC=clang
           command: -j -Orecurse READLINE=libreadline test
+        continue-on-error: true
+
+      - name: create ${{ env.ARCHIVE_TGT }}
+        if: ${{ matrix.os != 'debian-jessie' }}
+        uses: mosteo-actions/docker-run@v1
+        with:
+          image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
+          command: ${{ env.ARCHIVE_TGT }}
+        if: >-
+          ${{ ( matrix.os == 'debian-jessie' &&
+                steps.test_jessie.outcome != 'success' ) ||
+              ( matrix.os != 'debian-jessie' &&
+                steps.test.outcome != 'success' ) }}
+      - name: create ${{ env.ARCHIVE_TGT }} (jessie)
+        if: ${{ matrix.os == 'debian-jessie' }}
+        uses: mosteo-actions/docker-run@v1
+        with:
+          image: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
+          command: READLINE=libreadline ${{ env.ARCHIVE_TGT }}
+        if: >-
+          ${{ ( matrix.os == 'debian-jessie' &&
+                steps.test_jessie.outcome != 'success' ) ||
+              ( matrix.os != 'debian-jessie' &&
+                steps.test.outcome != 'success' ) }}
+
+      - name: upload binary archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-${{ matrix.os }}-${{ matrix.variant.arch }}
+          path: ${{ env.ARCHIVE_TGT }}
+          overwrite: true
+        if: >-
+          ${{ ( matrix.os == 'debian-jessie' &&
+                steps.test_jessie.outcome != 'success' ) ||
+              ( matrix.os != 'debian-jessie' &&
+                steps.test.outcome != 'success' ) }}
+
+      - name: fail
+        run: /bin/false
+        if: >-
+          ${{ ( matrix.os == 'debian-jessie' &&
+                steps.test_jessie.outcome != 'success' ) ||
+              ( matrix.os != 'debian-jessie' &&
+                steps.test.outcome != 'success' ) }}
 
   root-test:
     needs: stable

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -26,7 +26,6 @@ on:
 
 jobs:
   stable:
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +38,12 @@ jobs:
           - fedora-43
           - opensuse-leap-15.6
           - opensuse-leap-16.0
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.variant.runner }}
     steps:
       - name: checkout
         uses: actions/checkout@v1
@@ -81,17 +86,15 @@ jobs:
       - name: upload binary archive
         uses: actions/upload-artifact@v4
         with:
-          name: native-${{ matrix.os }}
+          name: native-${{ matrix.os }}-${{ matrix.variant.arch }}
           path: ${{ env.ARCHIVE_TGT }}
           overwrite: true
 
   clang:
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         os:
-          - debian-jessie
           - debian-buster
           - debian-bullseye
           - debian-bookworm
@@ -99,6 +102,17 @@ jobs:
           - fedora-43
           - opensuse-leap-15.6
           - opensuse-leap-16.0
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+        include:
+          - os: debian-jessie
+            variant:
+              arch: x86_64
+              runner: ubuntu-24.04
+    runs-on: ${{ matrix.variant.runner }}
     steps:
       - name: checkout
         uses: actions/checkout@v1
@@ -119,7 +133,6 @@ jobs:
           command: -j -Orecurse READLINE=libreadline test
 
   root-test:
-    runs-on: ubuntu-24.04
     needs: stable
     strategy:
       fail-fast: false
@@ -133,6 +146,12 @@ jobs:
           - fedora-43
           - opensuse-leap-15.6
           - opensuse-leap-16.0
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.variant.runner }}
     steps:
       - name: mpath
         run: sudo modprobe dm_multipath
@@ -145,7 +164,7 @@ jobs:
       - name: download binary archive
         uses: actions/download-artifact@v4
         with:
-          name: native-${{ matrix.os }}
+          name: native-${{ matrix.os }}-${{ matrix.variant.arch }}
       - name: unpack binary archive
         run: cpio -idv < test-progs.cpio
         if: ${{ startswith(matrix.os, 'opensuse-leap-15') }}

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -41,21 +41,38 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
+        compiler:
+          - gcc
+          - clang
         include:
           - os: alpine
             variant:
               arch: x86_64
               runner: ubuntu-24.04
+            compiler: gcc
+          - os: alpine
+            variant:
+              arch: x86_64
+              runner: ubuntu-24.04
+            compiler: clang
     runs-on: ${{ matrix.variant.runner }}
     container: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@v1
       - name: build and test
-        run: make READLINE=libreadline -j -Orecurse test
-      - name: clean
-        run: make -j -Orecurse clean
-      - name: clang
-        env:
-          CC: clang
-        run: make READLINE=libedit -j -Orecurse test
+        id: test
+        run: make CC=${{ matrix.compiler }} READLINE=libreadline -j -Orecurse test
+        continue-on-error: true
+      - name: create binary archive
+        run: make test-progs.tar
+        if: steps.test.outcome != 'success'
+      - name: upload binary archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.os }}-${{ matrix.variant.arch }}-${{ matrix.compiler }}
+          path: test-progs.tar
+        if: steps.test.outcome != 'success'
+      - name: fail
+        run: /bin/false
+        if: steps.test.outcome != 'success'

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v1
       - name: build and test
         id: test
-        run: make CC=${{ matrix.compiler }} READLINE=libreadline -j -Orecurse test
+        run: make CC=${{ matrix.compiler }} READLINE=libreadline -j$(nproc) -Orecurse test
         continue-on-error: true
       - name: create binary archive
         run: make test-progs.tar

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   rolling:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -29,15 +29,24 @@ on:
 
 jobs:
   rolling:
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         os:
           - debian-sid
-          - alpine
           - opensuse-tumbleweed
           - fedora-rawhide
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+        include:
+          - os: alpine
+            variant:
+              arch: x86_64
+              runner: ubuntu-24.04
+    runs-on: ${{ matrix.variant.runner }}
     container: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
     steps:
       - name: checkout

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -59,7 +59,7 @@ jobs:
     container: ghcr.io/mwilck/multipath-build-${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: build and test
         id: test
         run: make CC=${{ matrix.compiler }} READLINE=libreadline -j$(nproc) -Orecurse test

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -9,6 +9,9 @@
 # Uncomment to disable dmevents polling support
 # ENABLE_DMEVENTS_POLL = 0
 #
+# Use ASAN=1 on make command line to enable address sanitizer
+ASAN := 
+#
 # Readline library to use, libedit, libreadline, or empty
 # Caution: Using libreadline may make the multipathd binary undistributable,
 # see https://github.com/opensvc/multipath-tools/issues/36
@@ -116,11 +119,11 @@ CPPFLAGS	:= $(FORTIFY_OPT) $(CPPFLAGS) $(D_URCU_VERSION) $(D_CMOCKA_VERSION) \
 		   -DDEFAULT_CONFIGFILE=\"$(TGTDIR)$(configfile)\" -DSTATE_DIR=\"$(TGTDIR)$(statedir)\" \
 		   -DEXTRAVERSION=\"$(EXTRAVERSION)\" -MMD -MP
 CFLAGS		:= -std=$(C_STD) $(CFLAGS) $(OPTFLAGS) $(WARNFLAGS) -pipe \
-		   -fexceptions -fno-strict-aliasing
+		   -fexceptions -fno-strict-aliasing $(if $(ASAN),-fsanitize=address)
 BIN_CFLAGS	:= -fPIE -DPIE
 LIB_CFLAGS	:= -fPIC
 SHARED_FLAGS	:= -shared
-LDFLAGS		:= $(LDFLAGS) -Wl,-z,relro -Wl,-z,now -Wl,-z,defs
+LDFLAGS		:= $(LDFLAGS) -Wl,-z,relro -Wl,-z,now -Wl,-z,defs $(if $(ASAN),-lasan)
 BIN_LDFLAGS	:= -pie
 
 # Source code directories. Don't modify.

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -109,7 +109,7 @@ WARNFLAGS	:= $(WERROR) -Wall -Wextra -Wformat=2 $(WFORMATOVERFLOW) -W$(ERROR)imp
 		  -W$(ERROR)implicit-function-declaration -W$(ERROR)format-security \
 		  $(WNOCLOBBERED) -W$(ERROR)cast-qual $(ERROR_DISCARDED_QUALIFIERS) $(W_URCU_TYPE_LIMITS)
 
-CPPFLAGS	:= $(FORTIFY_OPT) $(CPPFLAGS) $(D_URCU_VERSION) \
+CPPFLAGS	:= $(FORTIFY_OPT) $(CPPFLAGS) $(D_URCU_VERSION) $(D_CMOCKA_VERSION) \
 		   -D_FILE_OFFSET_BITS=64 \
 		   -DBIN_DIR=\"$(bindir)\" -DMULTIPATH_DIR=\"$(TGTDIR)$(plugindir)\" \
 		   -DRUNTIME_DIR=\"$(runtimedir)\" -DCONFIG_DIR=\"$(TGTDIR)$(configdir)\" \

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -116,7 +116,7 @@ CPPFLAGS	:= $(FORTIFY_OPT) $(CPPFLAGS) $(D_URCU_VERSION) $(D_CMOCKA_VERSION) \
 		   -DDEFAULT_CONFIGFILE=\"$(TGTDIR)$(configfile)\" -DSTATE_DIR=\"$(TGTDIR)$(statedir)\" \
 		   -DEXTRAVERSION=\"$(EXTRAVERSION)\" -MMD -MP
 CFLAGS		:= -std=$(C_STD) $(CFLAGS) $(OPTFLAGS) $(WARNFLAGS) -pipe \
-		   -fexceptions
+		   -fexceptions -fno-strict-aliasing
 BIN_CFLAGS	:= -fPIE -DPIE
 LIB_CFLAGS	:= -fPIC
 SHARED_FLAGS	:= -shared

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -12,6 +12,9 @@
 # Use ASAN=1 on make command line to enable address sanitizer
 ASAN := 
 #
+# Override on make command line if desired
+OPT := -O2
+
 # Readline library to use, libedit, libreadline, or empty
 # Caution: Using libreadline may make the multipathd binary undistributable,
 # see https://github.com/opensvc/multipath-tools/issues/36
@@ -102,7 +105,7 @@ SYSTEMD_LIBDEPS := $(if $(SYSTEMD),$(if $(shell test $(SYSTEMD) -gt 209 && echo 
 MODPROBE_UNIT := $(shell test "0$(SYSTEMD)" -lt 245 2>/dev/null || \
 			echo "modprobe@dm_multipath.service")
 
-OPTFLAGS	:= -O2 -g $(STACKPROT) --param=ssp-buffer-size=4
+OPTFLAGS	:= $(OPT) -g $(STACKPROT) --param=ssp-buffer-size=4
 
 # Set WARN_ONLY=1 to avoid compilation erroring out due to warnings. Useful during development.
 WARN_ONLY       :=

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,37 @@
 # multipath-tools Release Notes
 
+## multipath-tools 0.10.6, 2026/01
+
+**Note:** This release includes a minor change of the libmultipath ABI.
+
+### Bug fixes
+
+* Fix `mpathpersist --report-capabilities` output. Fixes 0.5.0.
+* Fix command descriptions in the multipathd man page. Fixes 0.9.2.
+* Fix an undefined symbol error with the LLVM lld linker.
+  Fixes [#132](https://github.com/opensvc/multipath-tools/issues/132), 0.10.0.
+* Fix ISO C23 compatibility issue causing errors with new compilers.
+* Fix memory leak caused by not joining the "init unwinder" thread.
+  Fixes 0.8.6.
+* Fix memory leaks in kpartx. Fixes any version.
+* Print the warning "setting scsi timeouts is unsupported for protocol" only
+  once per protocol. Fixes 0.9.0.
+* Make sure multipath-tools is compiled with the compiler flag
+  `-fno-strict-aliasing`. This turns out to be necessary because our code
+  uses techniques like `container_of()` which don't work well with
+  strict aliasing rules.
+  Fixes [#130](https://github.com/opensvc/multipath-tools/issues/130).
+
+### Other changes
+
+* Hardware table: add Seagate Exos and Nytro series.
+* Avoid joining threads twice with liburcu 0.14.0 and newer.
+* CI updates (GitHub workflows).
+* Fix CI for cmocka 2.0 by adding the `-Wno-error=deprecated-declarations`
+  compiler flag.
+  Fixes [#129](https://github.com/opensvc/multipath-tools/issues/129)
+* Add the ASAN=1 and OPT= make variables (see README.md).
+
 ## multipath-tools 0.10.5, 2025/10
 
 ### Other changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
   uses techniques like `container_of()` which don't work well with
   strict aliasing rules.
   Fixes [#130](https://github.com/opensvc/multipath-tools/issues/130).
+* Fix initialization of paths that were offline during path detection.
+* Fix printing the "path offline" log message for offline paths that don't
+  have a path checker configured.
+* kpartx: Fix freeing static buffer when operating on regular files.
+  Fixes [#139](https://github.com/opensvc/multipath-tools/issues/139).
 
 ### Other changes
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ See "Passing standard compiler flags" below for an exception.
 The following variables can be passed to the `make` command line:
 
  * `V=1`: enable verbose build.
+ * `OPT=`: set optimization flags. You may want to set `OPT="-O0"` for
+   debugging, for example. The default is `-O2`. Note that it is also
+   possible to set `OPTFLAGS`, which takes precedence over `OPT`. `OPTFLAGS`
+   sets additional options by default, which are intended for distribution
+   build environments to override. For quick customization of the optimization
+   level, use `OPT`.
  * `ASAN=1`: Enable
    [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer)
    during build for debugging memory allocation. This is off by default.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ See "Passing standard compiler flags" below for an exception.
 The following variables can be passed to the `make` command line:
 
  * `V=1`: enable verbose build.
+ * `ASAN=1`: Enable
+   [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer)
+   during build for debugging memory allocation. This is off by default.
  * `plugindir="/some/path"`: directory where libmultipath plugins (path
    checkers, prioritizers, and foreign multipath support) will be looked up.
    This used to be the run-time option `multipath_dir` in earlier versions.

--- a/create-config.mk
+++ b/create-config.mk
@@ -77,6 +77,10 @@ URCU_VERSION = $(shell \
 	$(PKG_CONFIG) --modversion liburcu 2>/dev/null | \
 			awk -F. '{ printf("-DURCU_VERSION=0x%06x", 256 * ( 256 * $$1 + $$2) + $$3); }')
 
+CMOCKA_VERSION = $(shell \
+	($(PKG_CONFIG) --modversion cmocka 2>/dev/null || echo "1.1.0" ) | \
+			awk -F. '{ printf("%d", 256 * ( 256 * $$1 + $$2) + $$3); }')
+
 DEFINES :=
 
 ifneq ($(call check_func,dm_task_no_flush,$(devmapper_incdir)/libdevmapper.h),0)
@@ -185,6 +189,7 @@ $(TOPDIR)/config.mk:	$(multipathdir)/autoconfig.h
 	@echo "FPIN_SUPPORT := $(FPIN_SUPPORT)" >$@
 	@echo "FORTIFY_OPT := $(FORTIFY_OPT)" >>$@
 	@echo "D_URCU_VERSION := $(call URCU_VERSION)" >>$@
+	@echo "CMOCKA_VERSION := $(call CMOCKA_VERSION)" >>$@
 	@echo "SYSTEMD := $(SYSTEMD)" >>$@
 	@echo "ANA_SUPPORT := $(ANA_SUPPORT)" >>$@
 	@echo "STACKPROT := $(call TEST_CC_OPTION,-fstack-protector-strong,-fstack-protector)" >>$@

--- a/kpartx/devmapper.c
+++ b/kpartx/devmapper.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004, 2005 Christophe Varoqui
  */
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -699,14 +700,13 @@ out:
 
 char *nondm_create_uuid(dev_t devt)
 {
-#define NONDM_UUID_BUFLEN (34 + sizeof(NONDM_UUID_PREFIX) + \
-			   sizeof(NONDM_UUID_SUFFIX))
-	static char uuid_buf[NONDM_UUID_BUFLEN];
-	snprintf(uuid_buf, sizeof(uuid_buf), "%s_%u:%u_%s",
-		 NONDM_UUID_PREFIX, major(devt), minor(devt),
-		 NONDM_UUID_SUFFIX);
-	uuid_buf[NONDM_UUID_BUFLEN-1] = '\0';
-	return uuid_buf;
+	char *uuid;
+
+	if (asprintf(&uuid, "%s_%u:%u_%s", NONDM_UUID_PREFIX, major(devt),
+		     minor(devt), NONDM_UUID_SUFFIX) >= 0)
+		return uuid;
+	else
+		return NULL;
 }
 
 int nondm_parse_uuid(const char *uuid, unsigned int *major, unsigned int *minor)

--- a/kpartx/kpartx.c
+++ b/kpartx/kpartx.c
@@ -245,7 +245,8 @@ main(int argc, char **argv){
 	char *loopdev __attribute__((cleanup(cleanup_charp))) = NULL;
 	char *delim __attribute__((cleanup(cleanup_charp))) = NULL;
 	char *uuid __attribute__((cleanup(cleanup_charp))) = NULL;
-	char *mapname __attribute__((cleanup(cleanup_charp))) = NULL;
+	char *_mapname __attribute__((cleanup(cleanup_charp))) = NULL;
+	char *mapname;
 	int hotplug = 0;
 	int loopcreated = 0;
 	struct stat buf;
@@ -388,10 +389,14 @@ main(int argc, char **argv){
 	off = find_devname_offset(device);
 
 	if (!loopdev) {
-		mapname = dm_mapname(major(buf.st_rdev), minor(buf.st_rdev));
-		if (mapname)
-			uuid = dm_mapuuid(mapname);
+		_mapname = dm_mapname(major(buf.st_rdev), minor(buf.st_rdev));
+		if (_mapname)
+			uuid = dm_mapuuid(_mapname);
 	}
+
+	mapname = _mapname;
+	if (!mapname)
+		mapname = device + off;
 
 	/*
 	 * We are called for a non-DM device.
@@ -401,9 +406,6 @@ main(int argc, char **argv){
 	 */
 	if (!uuid && !(what == DELETE && force_devmap))
 		uuid = nondm_create_uuid(buf.st_rdev);
-
-	if (!mapname)
-		mapname = device + off;
 
 	if (delim == NULL) {
 		delim = xmalloc(DELIM_SIZE);

--- a/kpartx/kpartx.c
+++ b/kpartx/kpartx.c
@@ -227,6 +227,11 @@ xmalloc (size_t size) {
 	return t;
 }
 
+static void cleanup_charp(char **p)
+{
+	free(*p);
+}
+
 int
 main(int argc, char **argv){
 	int i, j, m, n, op, off, arg, c, d, ro=0;
@@ -237,10 +242,10 @@ main(int argc, char **argv){
 	char *type, *diskdevice, *device, *progname;
 	int verbose = 0;
 	char partname[PARTNAME_SIZE], params[PARTNAME_SIZE + 16];
-	char * loopdev = NULL;
-	char * delim = NULL;
-	char *uuid = NULL;
-	char *mapname = NULL;
+	char *loopdev __attribute__((cleanup(cleanup_charp))) = NULL;
+	char *delim __attribute__((cleanup(cleanup_charp))) = NULL;
+	char *uuid __attribute__((cleanup(cleanup_charp))) = NULL;
+	char *mapname __attribute__((cleanup(cleanup_charp))) = NULL;
 	int hotplug = 0;
 	int loopcreated = 0;
 	struct stat buf;
@@ -292,7 +297,9 @@ main(int argc, char **argv){
 			verbose = 1;
 			break;
 		case 'p':
-			delim = optarg;
+			delim = strdup(optarg);
+			if (!delim)
+				exit(1);
 			break;
 		case 'l':
 			what = LIST;
@@ -674,7 +681,6 @@ main(int argc, char **argv){
 		if (verbose)
 			fprintf(stderr, "loop deleted : %s\n", device);
 	}
-
 end:
 	dm_lib_exit();
 

--- a/kpartx/kpartx.c
+++ b/kpartx/kpartx.c
@@ -404,8 +404,11 @@ main(int argc, char **argv){
 	 * This allows deletion of partitions created with older kpartx
 	 * versions which didn't use the fake UUID during creation.
 	 */
-	if (!uuid && !(what == DELETE && force_devmap))
+	if (!uuid && !(what == DELETE && force_devmap)) {
 		uuid = nondm_create_uuid(buf.st_rdev);
+		if (!uuid)
+			exit(1);
+	}
 
 	if (delim == NULL) {
 		delim = xmalloc(DELIM_SIZE);

--- a/libmpathpersist/mpath_persist.h
+++ b/libmpathpersist/mpath_persist.h
@@ -107,7 +107,9 @@ struct prin_capdescr
 {
 	uint16_t length;
 	uint8_t  flags[2];
-	uint16_t pr_type_mask;
+	uint16_t pr_type_mask; /* The two bytes of the type mask are treated
+				  as a single big-endian number. So the valid
+				  type bits are 0xea01 */
 	uint16_t _reserved;
 };
 

--- a/libmpathutil/parser.c
+++ b/libmpathutil/parser.c
@@ -153,7 +153,7 @@ snprint_keyword(struct strbuf *buff, const char *fmt, struct keyword *kw,
 		const void *data)
 {
 	int r = 0;
-	char *f;
+	const char *f;
 	struct config *conf;
 	STRBUF_ON_STACK(sbuf);
 

--- a/libmpathutil/util.c
+++ b/libmpathutil/util.c
@@ -38,7 +38,7 @@ strchop(char *str)
  */
 const char *libmp_basename(const char *filename)
 {
-	char *p = strrchr(filename, '/');
+	const char *p = strrchr(filename, '/');
 	return p ? p + 1 : filename;
 }
 

--- a/libmultipath/discovery.c
+++ b/libmultipath/discovery.c
@@ -879,6 +879,8 @@ scsi_tmo_error_msg(struct path *pp)
 	STRBUF_ON_STACK(proto_buf);
 	unsigned int proto_id = bus_protocol_id(pp);
 
+	if (is_bit_set_in_bitfield(proto_id, bf))
+		return;
 	snprint_path_protocol(&proto_buf, pp);
 	condlog(2, "%s: setting scsi timeouts is unsupported for protocol %s",
 		pp->dev, get_strbuf_str(&proto_buf));

--- a/libmultipath/discovery.h
+++ b/libmultipath/discovery.h
@@ -33,7 +33,7 @@ struct config;
 int path_discovery (vector pathvec, int flag);
 int path_get_tpgs(struct path *pp); /* This function never returns TPGS_UNDEF */
 int do_tur (char *);
-int path_offline (struct path *);
+int path_sysfs_state(struct path *);
 int get_state (struct path * pp, struct config * conf, int daemon, int state);
 int get_vpd_sgio (int fd, int pg, int vend_id, char * str, int maxlen);
 int pathinfo (struct path * pp, struct config * conf, int mask);

--- a/libmultipath/hwtable.c
+++ b/libmultipath/hwtable.c
@@ -682,7 +682,7 @@ static struct hwentry default_hw[] = {
 		.pgfailback    = -FAILBACK_IMMEDIATE,
 	},
 	{
-		// Storwize V5000/V7000 lines / SAN Volume Controller (SVC)
+		// Storwize V3x00/V5000/V7000 lines / SAN Volume Controller (SVC)
 		// Flex System V7000 / FlashSystem V840/V9000 and 5x00/7x00/9x00/Cx00
 		.vendor        = "IBM",
 		.product       = "^2145",

--- a/libmultipath/hwtable.c
+++ b/libmultipath/hwtable.c
@@ -1326,6 +1326,15 @@ static struct hwentry default_hw[] = {
 		.prio_name     = PRIO_ALUA,
 		.no_path_retry = 30,
 	},
+	{
+		// Exos / Nytro series
+		.vendor        = "SEAGATE",
+		.product       = "^[456]",
+		.pgpolicy      = GROUP_BY_PRIO,
+		.pgfailback    = -FAILBACK_IMMEDIATE,
+		.prio_name     = PRIO_ALUA,
+		.no_path_retry = 30,
+	},
 	/*
 	 * AccelStor
 	 */

--- a/libmultipath/libmultipath.version
+++ b/libmultipath/libmultipath.version
@@ -43,7 +43,7 @@ LIBMPATHCOMMON_1.0.0 {
 	put_multipath_config;
 };
 
-LIBMULTIPATH_26.0.0 {
+LIBMULTIPATH_26.1.0 {
 global:
 	/* symbols referenced by multipath and multipathd */
 	add_foreign;
@@ -146,7 +146,7 @@ global:
 	path_discovery;
 	path_get_tpgs;
 	pathinfo;
-	path_offline;
+	path_sysfs_state;
 	print_all_paths;
 	print_foreign_topology;
 	print_multipath_topology__;

--- a/libmultipath/libmultipath.version
+++ b/libmultipath/libmultipath.version
@@ -81,7 +81,6 @@ global:
 	dm_geteventnr;
 	dm_get_major_minor;
 	dm_get_maps;
-	dm_get_multipath;
 	dm_is_mpath;
 	dm_mapname;
 	dm_prereq;

--- a/libmultipath/print.c
+++ b/libmultipath/print.c
@@ -514,7 +514,7 @@ snprint_offline (struct strbuf *buff, const struct path * pp)
 {
 	if (!pp || !pp->mpp)
 		return append_strbuf_str(buff, "unknown");
-	else if (pp->offline)
+	else if (pp->sysfs_state == PATH_DOWN)
 		return append_strbuf_str(buff, "offline");
 	else
 		return append_strbuf_str(buff, "running");

--- a/libmultipath/prkey.c
+++ b/libmultipath/prkey.c
@@ -50,7 +50,7 @@ static int parse_prkey(const char *ptr, uint64_t *prkey)
 	return 0;
 }
 
-int parse_prkey_flags(const char *ptr, uint64_t *prkey, uint8_t *flags)
+int parse_prkey_flags(char *ptr, uint64_t *prkey, uint8_t *flags)
 {
 	char *flagstr;
 

--- a/libmultipath/prkey.h
+++ b/libmultipath/prkey.h
@@ -15,7 +15,7 @@
 
 int print_reservation_key(struct strbuf *buff,
 			  struct be64 key, uint8_t flags, int source);
-int parse_prkey_flags(const char *ptr, uint64_t *prkey, uint8_t *flags);
+int parse_prkey_flags(char *ptr, uint64_t *prkey, uint8_t *flags);
 int set_prkey(struct config *conf, struct multipath *mpp,
 	      uint64_t prkey, uint8_t sa_flags);
 int get_prkey(struct multipath *mpp, uint64_t *prkey, uint8_t *sa_flags);

--- a/libmultipath/structs.h
+++ b/libmultipath/structs.h
@@ -362,7 +362,7 @@ struct path {
 	unsigned int tick;
 	unsigned int pending_ticks;
 	int bus;
-	int offline;
+	int sysfs_state;
 	int state;
 	int dmstate;
 	int chkrstate;

--- a/libmultipath/version.h
+++ b/libmultipath/version.h
@@ -20,9 +20,9 @@
 #ifndef VERSION_H_INCLUDED
 #define VERSION_H_INCLUDED
 
-#define VERSION_CODE 0x000A05
+#define VERSION_CODE 0x000A06
 /* MMDDYY, in hex */
-#define DATE_CODE    0x0A1B19
+#define DATE_CODE    0x01141A
 
 #define PROG    "multipath-tools"
 

--- a/mpathpersist/main.c
+++ b/mpathpersist/main.c
@@ -750,25 +750,42 @@ void mpath_print_buf_readcap( struct prin_resp *pr_buff)
 
 	printf("Report capabilities response:\n");
 
-	printf("  Compatible Reservation Handling(CRH): %d\n", !!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x10));
-	printf("  Specify Initiator Ports Capable(SIP_C): %d\n",!!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x8));
-	printf("  All Target Ports Capable(ATP_C): %d\n",!!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x4 ));
-	printf("  Persist Through Power Loss Capable(PTPL_C): %d\n",!!(pr_buff->prin_descriptor.prin_readcap.flags[0]));
-	printf("  Type Mask Valid(TMV): %d\n", !!(pr_buff->prin_descriptor.prin_readcap.flags[1] & 0x80));
-	printf("  Allow Commands: %d\n", !!(( pr_buff->prin_descriptor.prin_readcap.flags[1] >> 4) & 0x7));
+	printf("  Compatible Reservation Handling(CRH): %d\n",
+	       !!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x10));
+	printf("  Specify Initiator Ports Capable(SIP_C): %d\n",
+	       !!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x8));
+	printf("  All Target Ports Capable(ATP_C): %d\n",
+	       !!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x4));
+	printf("  Persist Through Power Loss Capable(PTPL_C): %d\n",
+	       !!(pr_buff->prin_descriptor.prin_readcap.flags[0] & 0x1));
+	printf("  Type Mask Valid(TMV): %d\n",
+	       !!(pr_buff->prin_descriptor.prin_readcap.flags[1] & 0x80));
+	printf("  Allow Commands: %d\n",
+	       !!((pr_buff->prin_descriptor.prin_readcap.flags[1] >> 4) & 0x7));
 	printf("  Persist Through Power Loss Active(PTPL_A): %d\n",
-			!!(pr_buff->prin_descriptor.prin_readcap.flags[1] & 0x1));
+	       !!(pr_buff->prin_descriptor.prin_readcap.flags[1] & 0x1));
 
 	if(pr_buff->prin_descriptor.prin_readcap.flags[1] & 0x80)
 	{
 		printf("    Support indicated in Type mask:\n");
 
-		printf("      %s: %d\n", pr_type_strs[7], pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x80);
-		printf("      %s: %d\n", pr_type_strs[6], pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x40);
-		printf("      %s: %d\n", pr_type_strs[5], pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x20);
-		printf("      %s: %d\n", pr_type_strs[3], pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x8);
-		printf("      %s: %d\n", pr_type_strs[1], pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x2);
-		printf("      %s: %d\n", pr_type_strs[8], pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x100);
+		printf("      %s: %d\n", pr_type_strs[7],
+		       !!(pr_buff->prin_descriptor.prin_readcap.pr_type_mask &
+			  0x8000));
+		printf("      %s: %d\n", pr_type_strs[6],
+		       !!(pr_buff->prin_descriptor.prin_readcap.pr_type_mask &
+			  0x4000));
+		printf("      %s: %d\n", pr_type_strs[5],
+		       !!(pr_buff->prin_descriptor.prin_readcap.pr_type_mask &
+			  0x2000));
+		printf("      %s: %d\n", pr_type_strs[3],
+		       !!(pr_buff->prin_descriptor.prin_readcap.pr_type_mask &
+			  0x800));
+		printf("      %s: %d\n", pr_type_strs[1],
+		       !!(pr_buff->prin_descriptor.prin_readcap.pr_type_mask &
+			  0x200));
+		printf("      %s: %d\n", pr_type_strs[8],
+		       !!(pr_buff->prin_descriptor.prin_readcap.pr_type_mask & 0x1));
 	}
 }
 

--- a/multipath/multipath.conf.5.in
+++ b/multipath/multipath.conf.5.in
@@ -197,22 +197,23 @@ kernel multipath target:
 .RS
 .TP 12
 .I "round-robin 0"
-Loop through every path in the path group, sending the same amount of I/O to
-each. Some aspects of behavior can be controlled with the attributes:
-\fIrr_min_io\fR, \fIrr_min_io_rq\fR and \fIrr_weight\fR.
+Choose the path for the next bunch of I/O by looping through every path in the
+path group, sending \fBthe same number of I/O requests\fR to each path. Some
+aspects of behavior can be controlled with the attributes: \fIrr_min_io\fR,
+\fIrr_min_io_rq\fR and \fIrr_weight\fR.
 .TP
 .I "queue-length 0"
-(Since 2.6.31 kernel) Choose the path for the next bunch of I/O based on the amount
-of outstanding I/O to the path.
+(Since 2.6.31 kernel) Choose the path for the next bunch of I/O based on \fBthe lowest
+number of outstanding in-flight I/O requests\fR to the path.
 .TP
 .I "service-time 0"
-(Since 2.6.31 kernel) Choose the path for the next bunch of I/O based on the amount
-of outstanding I/O to the path and its relative throughput.
+(Since 2.6.31 kernel) Choose the path for the next bunch of I/O based on \fBthe
+lowest total size (in bytes) of outstanding in-flight I/O requests\fR to the path.
 .TP
 .I "historical-service-time 0"
-(Since 5.8 kernel) Choose the path for the next bunch of I/O based on the
-estimation of future service time based on the history of previous I/O submitted
-to each path.
+(Since 5.8 kernel) Choose the path for the next bunch of I/O with \fBa dynamic
+algorithm based on the historical service time and the number of outstanding
+in-flight I/O requests\fR to the path.
 .TP
 The default is: \fBservice-time 0\fR
 .RE

--- a/multipathd/init_unwinder.c
+++ b/multipathd/init_unwinder.c
@@ -34,5 +34,7 @@ int init_unwinder(void)
 
 	pthread_mutex_unlock(&dummy_mtx);
 
-	return pthread_cancel(dummy);
+	rc = pthread_cancel(dummy);
+	pthread_join(dummy, NULL);
+	return rc;
 }

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -3528,18 +3528,21 @@ static struct call_rcu_data *mp_rcu_data;
 
 static void cleanup_rcu(void)
 {
-	pthread_t rcu_thread;
-
 	/* Wait for any pending RCU calls */
 	rcu_barrier();
 	if (mp_rcu_data != NULL) {
+#if (URCU_VERSION < 0x000E00)
+		pthread_t rcu_thread;
 		rcu_thread = get_call_rcu_thread(mp_rcu_data);
+#endif
 		/* detach this thread from the RCU thread */
 		set_thread_call_rcu_data(NULL);
 		synchronize_rcu();
 		/* tell RCU thread to exit */
 		call_rcu_data_free(mp_rcu_data);
+#if (URCU_VERSION < 0x000E00)
 		pthread_join(rcu_thread, NULL);
+#endif
 	}
 	rcu_unregister_thread();
 }

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -3582,7 +3582,7 @@ child (__attribute__((unused)) void *param)
 	int rc;
 	struct config *conf;
 	char *envp;
-	enum daemon_status state;
+	enum daemon_status state = DAEMON_INIT;
 	int exit_code = 1;
 	int fpin_marginal_paths = 0;
 

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -96,7 +96,7 @@ void * mpath_pr_event_handler_fn (void * );
 do {								\
 	if (pp->mpp && checker_selected(&pp->checker) &&	\
 	    lvl <= libmp_verbosity) {					\
-		if (pp->offline)				\
+		if (pp->sysfs_state == PATH_DOWN)		\
 			condlog(lvl, "%s: %s - path offline",	\
 				pp->mpp->alias, pp->dev);	\
 		else  {						\
@@ -2329,7 +2329,7 @@ check_path_state(struct path *pp)
 	int newstate;
 	struct config *conf;
 
-	newstate = path_offline(pp);
+	newstate = path_sysfs_state(pp);
 	if (newstate == PATH_UP) {
 		conf = get_multipath_config();
 		pthread_cleanup_push(put_multipath_config, conf);

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -94,12 +94,11 @@ void * mpath_pr_event_handler_fn (void * );
 
 #define LOG_MSG(lvl, pp)					\
 do {								\
-	if (pp->mpp && checker_selected(&pp->checker) &&	\
-	    lvl <= libmp_verbosity) {					\
-		if (pp->sysfs_state == PATH_DOWN)		\
+	if (pp->mpp && lvl <= libmp_verbosity) {		\
+		if (pp->sysfs_state != PATH_UP)			\
 			condlog(lvl, "%s: %s - path offline",	\
 				pp->mpp->alias, pp->dev);	\
-		else  {						\
+		else if (checker_selected(&pp->checker)) {	\
 			const char *__m =			\
 				checker_message(&pp->checker);	\
 								\

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -2395,6 +2395,25 @@ enum check_path_return {
 	CHECK_PATH_SKIPPED,
 	CHECK_PATH_REMOVED,
 };
+/*
+ * pp->wwid should never be empty when this function is called, but if it
+ * is, this function can set it.
+ */
+static bool new_path_wwid_changed(struct path *pp, int state)
+{
+	char wwid[WWID_SIZE];
+
+	strlcpy(wwid, pp->wwid, WWID_SIZE);
+	if (get_uid(pp, state, pp->udev, 1) != 0) {
+		strlcpy(pp->wwid, wwid, WWID_SIZE);
+		return false;
+	}
+	if (strlen(wwid) && strncmp(wwid, pp->wwid, WWID_SIZE) != 0) {
+		strlcpy(pp->wwid, wwid, WWID_SIZE);
+		return true;
+	}
+	return false;
+}
 
 static int
 do_check_path (struct vectors * vecs, struct path * pp)
@@ -2431,14 +2450,33 @@ do_check_path (struct vectors * vecs, struct path * pp)
 		pp->tick = 1;
 		return CHECK_PATH_SKIPPED;
 	}
-	if (pp->recheck_wwid == RECHECK_WWID_ON &&
-	    (newstate == PATH_UP || newstate == PATH_GHOST) &&
+
+	if ((newstate == PATH_UP || newstate == PATH_GHOST) &&
 	    ((pp->state != PATH_UP && pp->state != PATH_GHOST) ||
-	     pp->dmstate == PSTATE_FAILED) &&
-	    check_path_wwid_change(pp)) {
-		condlog(0, "%s: path wwid change detected. Removing", pp->dev);
-		return handle_path_wwid_change(pp, vecs)? CHECK_PATH_REMOVED :
-							  CHECK_PATH_SKIPPED;
+	     pp->dmstate == PSTATE_FAILED)) {
+		bool wwid_changed = false;
+
+		if (pp->initialized == INIT_NEW) {
+			/*
+			 * Path was added to map while offline, mark it as
+			 * initialized.
+			 * DI_SYSFS was checked when the path was added
+			 * DI_CHECKER just got checked
+			 * DI_WWID is about to be checked
+			 * DI_PRIO will get checked at the end of this checker
+			 * loop
+			 */
+			pp->initialized = INIT_OK;
+			wwid_changed = new_path_wwid_changed(pp, newstate);
+		} else if (pp->recheck_wwid == RECHECK_WWID_ON)
+			wwid_changed = check_path_wwid_change(pp);
+		if (wwid_changed) {
+			condlog(0, "%s: path wwid change detected. Removing",
+				pp->dev);
+			return handle_path_wwid_change(pp, vecs)
+				       ? CHECK_PATH_REMOVED
+				       : CHECK_PATH_SKIPPED;
+		}
 	}
 	if (pp->mpp->synced_count == 0) {
 		do_sync_mpp(vecs, pp->mpp);

--- a/multipathd/multipathd.8.in
+++ b/multipathd/multipathd.8.in
@@ -313,48 +313,48 @@ will not be disabled when the daemon stops.
 Restores configured queue_without_daemon mode.
 .
 .TP
-.B map|multipath $map setprstatus
+.B setprstatus map|multipath $map
 Enable persistent reservation management on $map.
 .
 .TP
-.B map|multipath $map unsetprstatus
+.B unsetprstatus map|multipath $map
 Disable persistent reservation management on $map.
 .
 .TP
-.B map|multipath $map getprstatus
+.B getprstatus map|multipath $map
 Get the current persistent reservation management status of $map.
 .
 .TP
-.B map|multipath $map getprkey
+.B getprkey map|multipath $map
 Get the current persistent reservation key associated with $map.
 .
 .TP
-.B map|multipath $map setprkey key $key
+.B setprkey map|multipath $map key $key
 Set the persistent reservation key associated with $map to $key in the
 \fIprkeys_file\fR. This key will only be used by multipathd if
 \fIreservation_key\fR is set to \fBfile\fR in \fI@CONFIGFILE@\fR.
 .
 .TP
-.B map|multipath $map unsetprkey
+.B unsetprkey map|multipath $map
 Remove the persistent reservation key associated with $map from the
 \fIprkeys_file\fR. This will only unset the key used by multipathd if
 \fIreservation_key\fR is set to \fBfile\fR in \fI@CONFIGFILE@\fR.
 .
 .TP
-.B path $path setmarginal
+.B setmarginal path $path
 move $path to a marginal pathgroup. The path will remain in the marginal
 path group until \fIunsetmarginal\fR is called. This command will only
 work if \fImarginal_pathgroups\fR is enabled and there is no Shaky paths
 detection method configured (see the multipath.conf man page for details).
 .
 .TP
-.B path $path unsetmarginal
+.B unsetmarginal path $path
 return marginal path $path to its normal pathgroup. This command will only
 work if \fImarginal_pathgroups\fR is enabled and there is no Shaky paths
 detection method configured (see the multipath.conf man page for details).
 .
 .TP
-.B map $map unsetmarginal
+.B unsetmarginal map $map
 return all marginal paths in $map to their normal pathgroups. This command
 will only work if \fImarginal_pathgroups\fR is enabled and there is no Shaky
 paths detection method configured (see the multipath.conf man page for details).

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,8 @@ TESTDIR := $(CURDIR)
 
 CPPFLAGS += -I$(multipathdir) -I$(mpathutildir) -I$(mpathcmddir) -I$(daemondir) \
 	-DTESTCONFDIR=\"$(TESTDIR)/conf.d\"
-CFLAGS += $(BIN_CFLAGS) -Wno-unused-parameter $(W_MISSING_INITIALIZERS)
+CFLAGS += $(BIN_CFLAGS) -Wno-unused-parameter $(W_MISSING_INITIALIZERS) \
+	$(if $(shell [ $(CMOCKA_VERSION) -ge 131072 ] && echo yes),-Wno-error=deprecated-declarations)
 LIBDEPS += -L. -L $(mpathutildir) -L$(mpathcmddir) -lmultipath -lmpathutil -lmpathcmd -lcmocka
 
 TESTS := uevent parser util dmevents hwtable blacklist unaligned vpd pgpolicy \


### PR DESCRIPTION
## multipath-tools 0.10.6, 2026/01

**Note:** This release includes a minor change of the libmultipath ABI.

### Bug fixes

* Fix `mpathpersist --report-capabilities` output. Fixes 0.5.0.
* Fix command descriptions in the multipathd man page. Fixes 0.9.2.
* Fix an undefined symbol error with the LLVM lld linker.
  Fixes [#132](https://github.com/opensvc/multipath-tools/issues/132), 0.10.0.
* Fix ISO C23 compatibility issue causing errors with new compilers.
* Fix memory leak caused by not joining the "init unwinder" thread.
  Fixes 0.8.6.
* Fix memory leaks in kpartx. Fixes any version.
* Print the warning "setting scsi timeouts is unsupported for protocol" only
  once per protocol. Fixes 0.9.0.
* Make sure multipath-tools is compiled with the compiler flag
  `-fno-strict-aliasing`. This turns out to be necessary because our code
  uses techniques like `container_of()` which don't work well with
  strict aliasing rules.
  Fixes [#130](https://github.com/opensvc/multipath-tools/issues/130).
* Fix initialization of paths that were offline during path detection.
* Fix printing the "path offline" log message for offline paths that don't
  have a path checker configured.
* kpartx: Fix freeing static buffer when operating on regular files.
  Fixes [#139](https://github.com/opensvc/multipath-tools/issues/139).

### Other changes

* Hardware table: add Seagate Exos and Nytro series.
* Avoid joining threads twice with liburcu 0.14.0 and newer.
* CI updates (GitHub workflows).
* Fix CI for cmocka 2.0 by adding the `-Wno-error=deprecated-declarations`
  compiler flag.
  Fixes [#129](https://github.com/opensvc/multipath-tools/issues/129)
* Add the ASAN=1 and OPT= make variables (see README.md).
