### PR TITLE
multipath-tools 0.14.1

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -15,6 +15,9 @@
 \b0x[0-9a-f]{8}\b
 \b0x[0-9a-f]{16}\b
 
+# Commit SHAs
+\b[0-9a-f]{7}\b
+
 # WWNN/WWPN (NAA identifiers)
 \b(?:0x)?10[0-9a-f]{14}\b
 \b(?:0x|3)?[25][0-9a-f]{15}\b

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -86,6 +86,23 @@ on:
     - 'opened'
     - 'reopened'
     - 'synchronize'
+    paths:
+    - '.github/workflows/spelling.yml'
+    - 'README*'
+    - 'NEWS.md'
+    - '**.3'
+    - '**.5'
+    - '**.8'
+    - '**.8'
+    - '**.in'
+    - '**.service'
+    - '**.socket'
+    - '**.rules'
+    - '**/libdmmp.h'
+    - '**/mpath_valid.h'
+    - '**/mpath_cmd.h'
+    - '**/mpath_persist.h'
+    - '.github/actions/spelling/*'
 
 jobs:
   spelling:

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,28 @@ release. These bug fixes will be tracked in stable branches.
 
 See [README.md](README.md) for additional information.
 
+## multipath-tools 0.14.1, 2026/01
+
+### Bug fixes
+
+* kpartx: Fix freeing static buffer when operating on regular files.
+  Fixes 0.14.0. Commit fab5d44.
+  Fixes [#139](https://github.com/opensvc/multipath-tools/issues/139).
+* Fix initialization of paths that were offline during path detection.
+  Commit 1942fb1.
+* Fix printing the "path offline" log message for offline paths that don't
+  have a path checker configured. Commit 1a364a1.
+
+### Other changes
+
+* If path devices that are members of multipath maps aren't detected during
+  multipathd startup or `reconfigure`, don't add them to newly created maps
+  in the first place. In previous versions, such paths would be added to the
+  maps, only to be removed later. Commit a04be55.
+* Improve the detection of "busy" state in the `show status` command, such
+  that reading udev events from udevd is also counted as busy.
+  Commit 7fdd93b.
+
 ## multipath-tools 0.14.0, 2026/01
 
 ### User-visible changes

--- a/kpartx/devmapper.c
+++ b/kpartx/devmapper.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004, 2005 Christophe Varoqui
  */
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -699,14 +700,13 @@ out:
 
 char *nondm_create_uuid(dev_t devt)
 {
-#define NONDM_UUID_BUFLEN (34 + sizeof(NONDM_UUID_PREFIX) + \
-			   sizeof(NONDM_UUID_SUFFIX))
-	static char uuid_buf[NONDM_UUID_BUFLEN];
-	snprintf(uuid_buf, sizeof(uuid_buf), "%s_%u:%u_%s",
-		 NONDM_UUID_PREFIX, major(devt), minor(devt),
-		 NONDM_UUID_SUFFIX);
-	uuid_buf[NONDM_UUID_BUFLEN-1] = '\0';
-	return uuid_buf;
+	char *uuid;
+
+	if (asprintf(&uuid, "%s_%u:%u_%s", NONDM_UUID_PREFIX, major(devt),
+		     minor(devt), NONDM_UUID_SUFFIX) >= 0)
+		return uuid;
+	else
+		return NULL;
 }
 
 int nondm_parse_uuid(const char *uuid, unsigned int *major, unsigned int *minor)

--- a/kpartx/kpartx.c
+++ b/kpartx/kpartx.c
@@ -334,8 +334,11 @@ main(int argc, char **argv){
 	 * This allows deletion of partitions created with older kpartx
 	 * versions which didn't use the fake UUID during creation.
 	 */
-	if (!uuid && !(what == DELETE && force_devmap))
+	if (!uuid && !(what == DELETE && force_devmap)) {
 		uuid = nondm_create_uuid(buf.st_rdev);
+		if (!uuid)
+			exit(1);
+	}
 
 	if (delim == NULL) {
 		delim = xmalloc(DELIM_SIZE);

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -1113,7 +1113,17 @@ int coalesce_paths (struct vectors *vecs, vector mpvec, char *refwwid,
 			continue;
 		}
 
-		/* 4. path is out of scope */
+		/*
+		 * 4. The path wasn't found in path_discovery. It only exists
+		 *    in an old map.
+		 */
+		if (pp1->initialized == INIT_PARTIAL ||
+		    pp1->initialized == INIT_REMOVED) {
+			orphan_path(pp1, "path not found");
+			continue;
+		}
+
+		/* 5. path is out of scope */
 		if (refwwid && strncmp(pp1->wwid, refwwid, WWID_SIZE - 1))
 			continue;
 

--- a/libmultipath/discovery.c
+++ b/libmultipath/discovery.c
@@ -2585,6 +2585,8 @@ blank:
 	 * Recoverable error, for example faulty or offline path
 	 */
 	pp->chkrstate = pp->state = PATH_DOWN;
+	if (mask & DI_IOCTL && pp->ioctl_info == IOCTL_INFO_NOT_REQUESTED)
+		pp->ioctl_info = IOCTL_INFO_SKIPPED;
 	if (pp->initialized == INIT_NEW || pp->initialized == INIT_FAILED)
 		memset(pp->wwid, 0, WWID_SIZE);
 

--- a/libmultipath/structs_vec.c
+++ b/libmultipath/structs_vec.c
@@ -315,7 +315,8 @@ int adopt_paths(vector pathvec, struct multipath *mpp,
 					pp->dev, mpp->alias);
 				continue;
 			}
-			if (pp->initialized == INIT_REMOVED)
+			if (pp->initialized == INIT_REMOVED ||
+			    pp->initialized == INIT_PARTIAL)
 				continue;
 			if (mpp->queue_mode == QUEUE_MODE_RQ &&
 			    pp->bus == SYSFS_BUS_NVME &&

--- a/libmultipath/version.h
+++ b/libmultipath/version.h
@@ -11,9 +11,9 @@
 #ifndef VERSION_H_INCLUDED
 #define VERSION_H_INCLUDED
 
-#define VERSION_CODE 0x000E00
+#define VERSION_CODE 0x000E01
 /* MMDDYY, in hex */
-#define DATE_CODE    0x01101A
+#define DATE_CODE    0x01171A
 
 #define PROG    "multipath-tools"
 

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -2572,6 +2572,26 @@ static int sync_mpp(struct vectors *vecs, struct multipath *mpp, unsigned int ti
 	return do_sync_mpp(vecs, mpp);
 }
 
+/*
+ * pp->wwid should never be empty when this function is called, but if it
+ * is, this function can set it.
+ */
+static bool new_path_wwid_changed(struct path *pp, int state)
+{
+	char wwid[WWID_SIZE];
+
+	strlcpy(wwid, pp->wwid, WWID_SIZE);
+	if (get_uid(pp, state, pp->udev, 1) != 0) {
+		strlcpy(pp->wwid, wwid, WWID_SIZE);
+		return false;
+	}
+	if (strlen(wwid) && strncmp(wwid, pp->wwid, WWID_SIZE) != 0) {
+		strlcpy(pp->wwid, wwid, WWID_SIZE);
+		return true;
+	}
+	return false;
+}
+
 static int
 update_path_state (struct vectors * vecs, struct path * pp)
 {
@@ -2601,14 +2621,33 @@ update_path_state (struct vectors * vecs, struct path * pp)
 		return CHECK_PATH_SKIPPED;
 	}
 
-	if (pp->recheck_wwid == RECHECK_WWID_ON &&
-	    (newstate == PATH_UP || newstate == PATH_GHOST) &&
+	if ((newstate == PATH_UP || newstate == PATH_GHOST) &&
 	    ((pp->state != PATH_UP && pp->state != PATH_GHOST) ||
-	     pp->dmstate == PSTATE_FAILED) &&
-	    check_path_wwid_change(pp)) {
-		condlog(0, "%s: path wwid change detected. Removing", pp->dev);
-		return handle_path_wwid_change(pp, vecs)? CHECK_PATH_REMOVED :
-							  CHECK_PATH_SKIPPED;
+	     pp->dmstate == PSTATE_FAILED)) {
+		bool wwid_changed = false;
+
+		if (pp->initialized == INIT_NEW) {
+			/*
+			 * Path was added to map while offline, mark it as
+			 * initialized.
+			 * DI_SYSFS was checked when the path was added
+			 * DI_IOCTL was checked when the checker was selected
+			 * DI_CHECKER just got checked
+			 * DI_WWID is about to be checked
+			 * DI_PRIO will get checked at the end of this checker
+			 * loop
+			 */
+			pp->initialized = INIT_OK;
+			wwid_changed = new_path_wwid_changed(pp, newstate);
+		} else if (pp->recheck_wwid == RECHECK_WWID_ON)
+			wwid_changed = check_path_wwid_change(pp);
+		if (wwid_changed) {
+			condlog(0, "%s: path wwid change detected. Removing",
+				pp->dev);
+			return handle_path_wwid_change(pp, vecs)
+				       ? CHECK_PATH_REMOVED
+				       : CHECK_PATH_SKIPPED;
+		}
 	}
 	if ((newstate != PATH_UP && newstate != PATH_GHOST &&
 	     newstate != PATH_PENDING) && (pp->state == PATH_DELAYED)) {

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -96,12 +96,11 @@ mpath_pr_event_handle(struct path *pp, unsigned int nr_keys_needed,
 
 #define LOG_MSG(lvl, pp)					\
 do {								\
-	if (pp->mpp && checker_selected(&pp->checker) &&	\
-	    lvl <= libmp_verbosity) {					\
-		if (pp->sysfs_state == PATH_DOWN)		\
+	if (pp->mpp && lvl <= libmp_verbosity) {		\
+		if (pp->sysfs_state != PATH_UP)			\
 			condlog(lvl, "%s: %s - path offline",	\
 				pp->mpp->alias, pp->dev);	\
-		else  {						\
+		else if (checker_selected(&pp->checker)) {	\
 			const char *__m =			\
 				checker_message(&pp->checker);	\
 								\


### PR DESCRIPTION
## multipath-tools 0.14.1, 2026/01

This is a minor update to incorporate some valuable patches from Ben that arrived shortly after the 0.14.0 release.

### Bug fixes

* kpartx: Fix freeing static buffer when operating on regular files.
  Fixes 0.14.0. Commit fab5d44.
  Fixes [#139](https://github.com/opensvc/multipath-tools/issues/139).
* Fix initialization of paths that were offline during path detection.
  Commit 1942fb1.
* Fix printing the "path offline" log message for offline paths that don't
  have a path checker configured. Commit 1a364a1.

### Other changes

* If path devices that are members of multipath maps aren't detected during
  multipathd startup or `reconfigure`, don't add them to newly created maps
  in the first place. In previous versions, such paths would be added to the
  maps, only to be removed later. Commit a04be55.
* Improve the detection of "busy" state in the `show status` command, such
  that reading udev events from udevd is also counted as busy.
  Commit 7fdd93b8.

## Shortlog

@bmarzins (4):
      multipathd: don't add removed/partial paths to new maps
      multipathd: finish initalization of paths added while offline
      multipathd: make "multipathd show status" busy checker better
      multipathd: print path offline message even without a checker

@mwilck (5):
      GitHub workflows: spelling: add path restrictions for PRs
      GitHub workflows: spelling: add pattern for 7-digit commit IDs
      kpartx: fix segfault when operating on regular files
      Update NEWS.md
      libmultipath: bump version to 0.14.1
