### PR TITLE
multipath-tools 0.14.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ release. These bug fixes will be tracked in stable branches.
 
 See [README.md](README.md) for additional information.
 
+## multipath-tools 0.14.3, 2026/02
+
+* Fix boot failures with multipath introduced in 0.14.1. Commit 01cc89c.
+
 ## multipath-tools 0.14.2, 2026/01
 
 ### Bug fixes

--- a/libmpathpersist/mpath_persistent_reserve_out.3
+++ b/libmpathpersist/mpath_persistent_reserve_out.3
@@ -6,7 +6,7 @@
 .\" Update the date below if you make any significant change.
 .\" ----------------------------------------------------------------------------
 .
-.TH MPATH_PERSISTENT_RESERVE_OUT 3 2024-02-09 Linux
+.TH MPATH_PERSISTENT_RESERVE_OUT 3 2026-02-02 Linux
 .
 .
 .\" ----------------------------------------------------------------------------
@@ -22,7 +22,7 @@ mpath_persistent_reserve_out \- send PROUT command to DM device
 .
 .B #include <mpath_persist.h>
 .P
-.BI "int mpath_persistent_reserve_out" "(int fd, int rq_servact, struct prin_resp *resp, int noisy, int verbose)"
+.BI "int mpath_persistent_reserve_out" "(int fd, int rq_servact, int rq_scope, unsigned int rq_type, struct prout_param_descriptor *paramp, int noisy, int verbose)"
 .P
 .
 .

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -1108,22 +1108,12 @@ int coalesce_paths (struct vectors *vecs, vector mpvec, char *refwwid,
 			continue;
 
 		/* 3. if path has disappeared */
-		if (pp1->state == PATH_REMOVED) {
+		if (pp1->state == PATH_REMOVED || pp1->initialized == INIT_REMOVED) {
 			orphan_path(pp1, "path removed");
 			continue;
 		}
 
-		/*
-		 * 4. The path wasn't found in path_discovery. It only exists
-		 *    in an old map.
-		 */
-		if (pp1->initialized == INIT_PARTIAL ||
-		    pp1->initialized == INIT_REMOVED) {
-			orphan_path(pp1, "path not found");
-			continue;
-		}
-
-		/* 5. path is out of scope */
+		/* 4. path is out of scope */
 		if (refwwid && strncmp(pp1->wwid, refwwid, WWID_SIZE - 1))
 			continue;
 

--- a/libmultipath/structs_vec.c
+++ b/libmultipath/structs_vec.c
@@ -315,8 +315,7 @@ int adopt_paths(vector pathvec, struct multipath *mpp,
 					pp->dev, mpp->alias);
 				continue;
 			}
-			if (pp->initialized == INIT_REMOVED ||
-			    pp->initialized == INIT_PARTIAL)
+			if (pp->initialized == INIT_REMOVED)
 				continue;
 			if (mpp->queue_mode == QUEUE_MODE_RQ &&
 			    pp->bus == SYSFS_BUS_NVME &&

--- a/libmultipath/version.h
+++ b/libmultipath/version.h
@@ -11,9 +11,9 @@
 #ifndef VERSION_H_INCLUDED
 #define VERSION_H_INCLUDED
 
-#define VERSION_CODE 0x000E02
+#define VERSION_CODE 0x000E03
 /* MMDDYY, in hex */
-#define DATE_CODE    0x011D1A
+#define DATE_CODE    0x02051A
 
 #define PROG    "multipath-tools"
 


### PR DESCRIPTION
## multipath-tools 0.14.3, 2026/02

* Fix boot failures with multipath introduced in 0.14.1. Commit 01cc89c.

## Shortlog

@bmarzins (1):
      multipathd: fix failures on booting from a multipath device

@mwilck (2):
      Update NEWS.md
      libmultipath: bump version to 0.14.3

@stefanhaRH (1):
      libmpathpersist: fix mpath_persistent_reserve_out(3) synopsis
