### PR TITLE
libmultipath: check get_word() result in disassemble_map()

### DIFF
--- a/libmultipath/dmparser.c
+++ b/libmultipath/dmparser.c
@@ -307,6 +307,8 @@ int disassemble_map(const struct vector_s *pathvec,
 			for (k = 0; k < num_paths_args; k++)
 				if (k == 0) {
 					p += get_word(p, &word);
+					if (!word)
+						goto out;
 					def_minio = atoi(word);
 					free(word);
 


### PR DESCRIPTION
  get_word() leaves *word == NULL and returns 0 if its internal
  calloc() fails, which can happen under memory pressure. Every
  other call site in disassemble_map() checks for this case, but the
  path-arguments loop skipped the check before calling atoi(word),
  causing a NULL-pointer dereference on the OOM path.

  Jump to the existing out1 label, which already frees word, to
  match the rest of the function and bail out cleanly.