### PR TITLE
multipath-tools 0.14.5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,5 +31,5 @@ ForEachMacros:
   - vector_foreach_slot_backwards
   - vector_foreach_slot_after
 Cpp11BracedListStyle: false
-ReflowComments: Never
+ReflowComments: false
 ---

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,28 @@ release. These bug fixes will be tracked in stable branches.
 
 See [README.md](README.md) for additional information.
 
+## multipath-tools 0.14.5, 2026/08
+
+### Vulnerability fixes
+
+* [DoS on mulipathd socket by blocking IPC send operations](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-hmcm-9cq4-r2xm)
+* [DoS on multipathd socket by exhausting connections]( https://github.com/opensvc/multipath-tools/security/advisories/GHSA-pvp6-c9p3-25fp)
+* [Heap Out-of-Bounds Read in Custom Format String Parser via Trailing `%`](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-g5mh-253r-jjw5)
+* [Heap out-of-bounds read in device-mapper-multipath ALUA RTPG parsing](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-pxwh-g75c-95pc)
+* [kpartx: Heap Out-of-Bounds Read in GPT Header Validation](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-p6rh-9x9j-3hvx)
+* [Path traversal in device-mapper-multipath failed_wwids management
+  ](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-gr7q-prfc-q636)
+* [libmpathpersist PRIN READ FULL STATUS parser — unbounded descriptor rewrite causes root heap overflow](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-hj7j-qr9h-5fv6)
+
+### Bug fixes
+
+* When parsing the device-mapper table of a multipath device, the result for
+  path arguments was not checked for `NULL`. This happens if the kernel
+  returns an invalid table with missing path arguments. Fix it by adding
+  a NULL check.
+  Fixes [#155](https://github.com/opensvc/multipath-tools/issues/155),
+  [#156](https://github.com/opensvc/multipath-tools/issues/156).
+
 ## multipath-tools 0.14.4, 2026/07
 
 ### User-visible changes

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ cherry-picked to these branches from the staging area. These branches are
 maintained by the multipath-tools maintainers on a best-effort basis. From
 time to time, minor releases will be made on these branches.
 
+Reporting Bugs
+--------------
+
+For **security related bugs**, see [SECURITY.md](SECURITY.md).
+
+For **regular bugs**, send an email to the and the maintainers
+(see [Mailing list](#Mailing-list) below), or use the
+[issue tracker on GitHub](https://github.com/opensvc/multipath-tools/issues).
+
 Releases
 ========
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.15.x   | :white_check_mark: |
+| 0.14.x   | :white_check_mark: |
+| 0.13.x   | :white_check_mark: |
+| 0.12.x   | :white_check_mark: |
+| 0.11.x   | :white_check_mark: |
+| 0.10.x   | :white_check_mark: |
+| < 0.10.0    | :x:                |
+
+Security fixes will be applied on the master branch first, and backported 
+to stable branches later.
+
+## Reporting a Vulnerability
+
+[Report a vulnerability on GitHub](https://github.com/opensvc/multipath-tools/security/advisories) 
+or send a PGP-encrypted email to the co-maintainers. The PGP public keys can
+be found e.g. on [keyserver.ubuntu.com](https://keyserver.ubuntu.com/). The
+PGP fingerprints (you can paste them into the search field of the keyserver) are:
+
+- Benjamin Marzinski: `06EC 597F 7546 F1DE 3D95  07AF 5D23 0580 0845 52A7`
+- Martin Wilck: `750E AD4B 2EDE B1A5 45D4  F5F4 67C5 86E6 8556 9754`

--- a/kpartx/gpt.c
+++ b/kpartx/gpt.c
@@ -316,7 +316,7 @@ static int is_gpt_valid(int fd, uint64_t lba, gpt_header **gpt,
 			gpt_entry **ptes, unsigned int ns)
 {
 	int rc = 0;		/* default to not valid */
-	uint32_t crc, origcrc;
+	uint32_t crc, origcrc, header_size;
 
 	if (!gpt || !ptes)
 		return 0;
@@ -336,8 +336,15 @@ static int is_gpt_valid(int fd, uint64_t lba, gpt_header **gpt,
 
 	/* Check the GUID Partition Table Header CRC */
 	origcrc = __le32_to_cpu((*gpt)->header_crc32);
+	header_size = __le32_to_cpu((*gpt)->header_size);
+	if (header_size < 92 || header_size > (uint32_t)get_sector_size(fd)) {
+		// printf("GPT Header size (%" PRIu32 ") is invalid\n", header_size);
+		free(*gpt);
+		*gpt = NULL;
+		return 0;
+	}
 	(*gpt)->header_crc32 = 0;
-	crc = efi_crc32(*gpt, __le32_to_cpu((*gpt)->header_size));
+	crc = efi_crc32(*gpt, header_size);
 	if (crc != origcrc) {
 		// printf( "GPTH CRC check failed, %x != %x.\n", origcrc, crc);
 		(*gpt)->header_crc32 = __cpu_to_le32(origcrc);

--- a/kpartx/gpt.c
+++ b/kpartx/gpt.c
@@ -315,7 +315,6 @@ alloc_read_gpt_header(int fd, uint64_t lba)
 static int is_gpt_valid(int fd, uint64_t lba, gpt_header **gpt,
 			gpt_entry **ptes, unsigned int ns)
 {
-	int rc = 0;		/* default to not valid */
 	uint32_t crc, origcrc, header_size;
 
 	if (!gpt || !ptes)
@@ -329,9 +328,7 @@ static int is_gpt_valid(int fd, uint64_t lba, gpt_header **gpt,
 		   printf("GUID Partition Table Header signature is wrong: %" PRIx64" != %" PRIx64 "\n",
 		   __le64_to_cpu((*gpt)->signature), GUID_PT_HEADER_SIGNATURE);
 		 */
-		free(*gpt);
-		*gpt = NULL;
-		return rc;
+		goto fail;
 	}
 
 	/* Check the GUID Partition Table Header CRC */
@@ -339,18 +336,13 @@ static int is_gpt_valid(int fd, uint64_t lba, gpt_header **gpt,
 	header_size = __le32_to_cpu((*gpt)->header_size);
 	if (header_size < 92 || header_size > (uint32_t)get_sector_size(fd)) {
 		// printf("GPT Header size (%" PRIu32 ") is invalid\n", header_size);
-		free(*gpt);
-		*gpt = NULL;
-		return 0;
+		goto fail;
 	}
 	(*gpt)->header_crc32 = 0;
 	crc = efi_crc32(*gpt, header_size);
 	if (crc != origcrc) {
 		// printf( "GPTH CRC check failed, %x != %x.\n", origcrc, crc);
-		(*gpt)->header_crc32 = __cpu_to_le32(origcrc);
-		free(*gpt);
-		*gpt = NULL;
-		return 0;
+		goto fail;
 	}
 	(*gpt)->header_crc32 = __cpu_to_le32(origcrc);
 
@@ -361,27 +353,27 @@ static int is_gpt_valid(int fd, uint64_t lba, gpt_header **gpt,
 		printf( "my_lba % PRIx64 "x != lba %"PRIx64 "x.\n",
 				__le64_to_cpu((*gpt)->my_lba), lba);
 		 */
-		free(*gpt);
-		*gpt = NULL;
-		return 0;
+		goto fail;
 	}
 
 	/* Check that sizeof_partition_entry has the correct value */
 	if (__le32_to_cpu((*gpt)->sizeof_partition_entry) != sizeof(gpt_entry)) {
 		// printf("GUID partition entry size check failed.\n");
-		free(*gpt);
-		*gpt = NULL;
-		return 0;
+		goto fail;
 	}
 
 	if (!(*ptes = alloc_read_gpt_entries(fd, *gpt, ns))) {
-		free(*gpt);
-		*gpt = NULL;
-		return 0;
+		goto fail;
 	}
 
 	/* We're done, all's well */
 	return 1;
+
+fail:
+	free(*gpt);
+	*gpt = NULL;
+	*ptes = NULL;
+	return 0;
 }
 
 /**

--- a/kpartx/gpt.c
+++ b/kpartx/gpt.c
@@ -193,6 +193,7 @@ read_lastoddsector(int fd, void *buffer, size_t count)
 	return !rc;
 }
 
+/* This function returns 0 for failure and 1 for success */
 static ssize_t
 read_lba(int fd, uint64_t lba, void *buffer, size_t bytes)
 {
@@ -203,11 +204,14 @@ read_lba(int fd, uint64_t lba, void *buffer, size_t bytes)
 
 	if (lseek(fd, offset, SEEK_SET) < 0)
 		return 0;
-	bytesread = read(fd, buffer, bytes);
+	while ((bytesread = read(fd, buffer, bytes)) < 0) {
+		if (errno != EINTR && errno != EAGAIN)
+			return 0;
+	}
 
 	lastlba = last_lba(fd);
 	if (!lastlba)
-		return bytesread;
+		return (bytesread == (ssize_t)bytes);
 
 	/* Kludge.  This is necessary to read/write the last
 	   block of an odd-sized disk, until Linux 2.5.x kernel fixes.
@@ -529,8 +533,8 @@ static int find_valid_gpt(int fd, gpt_header **gpt, gpt_entry **ptes, unsigned i
 	if (aligned_malloc((void **)&legacymbr, get_sector_size(fd),
 			   &size) == 0) {
 		memset(legacymbr, 0, size);
-		read_lba(fd, 0, (uint8_t *) legacymbr, size);
-		good_pmbr = is_pmbr_valid(legacymbr);
+		if (read_lba(fd, 0, (uint8_t *)legacymbr, size))
+			good_pmbr = is_pmbr_valid(legacymbr);
 		free(legacymbr);
 		legacymbr=NULL;
 	}

--- a/libmpathpersist/mpath_pr_ioctl.c
+++ b/libmpathpersist/mpath_pr_ioctl.c
@@ -264,7 +264,14 @@ static void mpath_format_readfullstatus(struct prin_resp *pr_buff)
 	p =(unsigned char *)tempbuff;
 	ppbuff = (char *)pr_buff->prin_descriptor.prin_readfd.private_buffer;
 
-	for (k = 0; k < additional_length; k += num, p += num) {
+	for (k = 0;
+	     k < additional_length &&
+	     ppbuff + sizeof(struct prin_fulldescr) <
+		     (char *)pr_buff->prin_descriptor.prin_readfd.private_buffer +
+			     MPATH_MAX_PARAM_LEN &&
+	     fdesc_count < MPATH_MX_TIDS;
+	     k += num, p += num, ++fdesc_count,
+	    ppbuff += sizeof(struct prin_fulldescr)) {
 		memcpy(&fdesc.key, p, 8 );
 		fdesc.flag = p[12];
 		fdesc.scope_type =  p[13];
@@ -284,10 +291,12 @@ static void mpath_format_readfullstatus(struct prin_resp *pr_buff)
 
 		num = 24 + tid_len_len;
 		memcpy(ppbuff, &fdesc, sizeof(struct prin_fulldescr));
-		pr_buff->prin_descriptor.prin_readfd.descriptors[fdesc_count]= (struct prin_fulldescr *)ppbuff;
-		ppbuff += sizeof(struct prin_fulldescr);
-		++fdesc_count;
+		pr_buff->prin_descriptor.prin_readfd.descriptors[fdesc_count] =
+			(struct prin_fulldescr *)ppbuff;
 	}
+	if (k < additional_length)
+		condlog(1, "%s: READ FULL STATUS result truncated, count=%u",
+			__func__, fdesc_count);
 
 	pr_buff->prin_descriptor.prin_readfd.number_of_descriptor = fdesc_count;
 

--- a/libmpathutil/uxsock.c
+++ b/libmpathutil/uxsock.c
@@ -52,7 +52,7 @@ int ux_socket_listen(const char *name)
 	if (name[0] != '@' && unlink(name) == -1 && errno != ENOENT)
 		condlog(1, "Failed to unlink %s", name);
 
-	fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	fd = socket(AF_LOCAL, SOCK_STREAM | SOCK_NONBLOCK, 0);
 	if (fd == -1) {
 		condlog(3, "Couldn't create ux_socket, error %d", errno);
 		return -1;

--- a/libmultipath/discovery.c
+++ b/libmultipath/discovery.c
@@ -2344,11 +2344,17 @@ get_uid (struct path * pp, int path_state, struct udev_device *udev,
 			pp->dev, origin, strerror(-len));
 		memset(pp->wwid, 0x0, WWID_SIZE);
 		return 1;
+	} else if (strcmp(pp->wwid, ".") == 0 || strcmp(pp->wwid, "..") == 0) {
+		condlog(2, "%s: %s uid '%s' in not valid", pp->dev, origin,
+			pp->wwid);
+		memset(pp->wwid, 0x0, WWID_SIZE);
+		return 1;
 	} else {
-		/* Strip any trailing blanks */
-		for (i = strlen(pp->wwid); i > 0 && pp->wwid[i-1] == ' '; i--);
-			/* no-op */
-		pp->wwid[i] = '\0';
+		strchop(pp->wwid);
+		for (i = 0; pp->wwid[i] != '\0'; i++) {
+			if (pp->wwid[i] == '/')
+				pp->wwid[i] = '_';
+		}
 	}
 	condlog((used_fallback)? 1 : 3, "%s: uid = %s (%s)", pp->dev,
 		*pp->wwid == '\0' ? "<empty>" : pp->wwid, origin);

--- a/libmultipath/dmparser.c
+++ b/libmultipath/dmparser.c
@@ -312,6 +312,8 @@ int disassemble_map(const struct vector_s *pathvec,
 			for (k = 0; k < num_paths_args; k++)
 				if (k == 0) {
 					p += get_word(p, &word);
+					if (!word)
+						goto out;
 					def_minio = atoi(word);
 					free(word);
 

--- a/libmultipath/print.c
+++ b/libmultipath/print.c
@@ -1099,6 +1099,8 @@ int snprint_multipath_header(struct strbuf *line, const char *format,
 			return rc;
 
 		format = f + 1;
+		if (*format == '\0')
+			break; /* tailing '%' */
 		if ((iwc = mpd_lookup(*format)) == -1)
 			continue; /* unknown wildcard */
 		data = &mpd[iwc];
@@ -1130,6 +1132,8 @@ int snprint_multipath__(const struct gen_multipath *gmp,
 			return rc;
 
 		format = f + 1;
+		if (*format == '\0')
+			break; /* tailing '%' */
 		if ((iwc = mpd_lookup(*format)) == -1)
 			continue; /* unknown wildcard */
 
@@ -1160,6 +1164,8 @@ int snprint_path_header(struct strbuf *line, const char *format,
 			return rc;
 
 		format = f + 1;
+		if (*format == '\0')
+			break; /* tailing '%' */
 		if ((iwc = pd_lookup(*format)) == -1)
 			continue; /* unknown wildcard */
 		data = &pd[iwc];
@@ -1190,6 +1196,8 @@ int snprint_path__(const struct gen_path *gp, struct strbuf *line,
 			return rc;
 
 		format = f + 1;
+		if (*format == '\0')
+			break; /* tailing '%' */
 		if ((iwc = pd_lookup(*format)) == -1)
 			continue; /* unknown wildcard */
 
@@ -1217,6 +1225,8 @@ int snprint_pathgroup__(const struct gen_pathgroup *ggp, struct strbuf *line,
 			return rc;
 
 		format = f + 1;
+		if (*format == '\0')
+			break; /* tailing '%' */
 
 		if ((rc = ggp->ops->snprint(ggp, line, *format)) < 0)
 			return rc;

--- a/libmultipath/prioritizers/alua_rtpg.c
+++ b/libmultipath/prioritizers/alua_rtpg.c
@@ -259,20 +259,6 @@ get_target_port_group(const struct path * pp)
 	scsi_buflen = get_unaligned_be16(&buf[2]) + 4;
 	if (scsi_buflen > VPD_BUFLEN)
 		scsi_buflen = VPD_BUFLEN;
-	if (rc < scsi_buflen) {
-		free(buf);
-		buf = (unsigned char *)malloc(scsi_buflen);
-		if (!buf) {
-			PRINT_DEBUG("malloc failed: could not allocate"
-				    "%u bytes", scsi_buflen);
-			return -RTPG_RTPG_FAILED;
-		}
-		buflen = scsi_buflen;
-		memset(buf, 0, buflen);
-		rc = do_inquiry(pp, 1, 0x83, buf, buflen);
-		if (rc < 0)
-			goto out;
-	}
 
 	data_len = rc;
 	if (data_len < scsi_buflen)

--- a/libmultipath/prioritizers/alua_rtpg.c
+++ b/libmultipath/prioritizers/alua_rtpg.c
@@ -178,9 +178,12 @@ retry:
 		PRINT_DEBUG("do_inquiry: retries exhausted!");
 		return -RTPG_INQUIRY_FAILED;
 	}
+	if (hdr.resid < 0 || (unsigned int)hdr.resid > hdr.dxfer_len)
+		/* resid failed sanity check*/
+		return -RTPG_RTPG_FAILED;
 	PRINT_HEX((unsigned char *) resp, resplen);
 
-	return 0;
+	return (int)hdr.dxfer_len - hdr.resid;
 }
 
 int do_inquiry(const struct path *pp, int evpd, unsigned int codepage,
@@ -202,7 +205,7 @@ int do_inquiry(const struct path *pp, int evpd, unsigned int codepage,
 
 		if (rc >= 0) {
 			PRINT_HEX((unsigned char *) resp, resplen);
-			return 0;
+			return rc;
 		}
 	}
 	return do_inquiry_sg(pp->fd, evpd, codepage, resp, resplen,
@@ -221,20 +224,18 @@ get_target_port_group_support(const struct path *pp)
 
 	memset((unsigned char *)&inq, 0, sizeof(inq));
 	rc = do_inquiry(pp, 0, 0x00, &inq, sizeof(inq));
-	if (!rc) {
-		rc = inquiry_data_get_tpgs(&inq);
-	}
-
-	return rc;
+	if (rc > (int)offsetof(struct inquiry_data, b5))
+		return inquiry_data_get_tpgs(&inq);
+	else
+		return -RTPG_INQUIRY_FAILED;
 }
 
 int
 get_target_port_group(const struct path * pp)
 {
-	unsigned char		*buf;
-	const struct vpd83_data *	vpd83;
+	unsigned char *buf;
 	const struct vpd83_dscr *	dscr;
-	int			rc;
+	int rc, data_len;
 	int			buflen, scsi_buflen;
 
 	buflen = VPD_BUFLEN;
@@ -250,10 +251,15 @@ get_target_port_group(const struct path * pp)
 	if (rc < 0)
 		goto out;
 
+	if (rc < 4) {
+		PRINT_DEBUG("do_inquiry only returned %d bytes", rc);
+		rc = -RTPG_RTPG_FAILED;
+		goto out;
+	}
 	scsi_buflen = get_unaligned_be16(&buf[2]) + 4;
-	if (scsi_buflen >= USHRT_MAX)
-		scsi_buflen = USHRT_MAX;
-	if (buflen < scsi_buflen) {
+	if (scsi_buflen > VPD_BUFLEN)
+		scsi_buflen = VPD_BUFLEN;
+	if (rc < scsi_buflen) {
 		free(buf);
 		buf = (unsigned char *)malloc(scsi_buflen);
 		if (!buf) {
@@ -268,14 +274,27 @@ get_target_port_group(const struct path * pp)
 			goto out;
 	}
 
-	vpd83 = (struct vpd83_data *) buf;
+	data_len = rc;
+	if (data_len < scsi_buflen)
+		PRINT_DEBUG("inquiry data trucated. Read %d of %d bytes",
+			    data_len, scsi_buflen);
 	rc = -RTPG_NO_TPG_IDENTIFIER;
-	FOR_EACH_VPD83_DSCR(vpd83, dscr) {
+	for (dscr = (const struct vpd83_dscr *)&buf[4];
+	     (const unsigned char *)(dscr + 1) <= buf + data_len &&
+	     dscr->data + dscr->length <= buf + data_len;
+	     dscr = (const struct vpd83_dscr *)(dscr->data + dscr->length)) {
 		if (vpd83_dscr_istype(dscr, IDTYPE_TARGET_PORT_GROUP)) {
 			const struct vpd83_tpg_dscr *p;
 			if (rc != -RTPG_NO_TPG_IDENTIFIER) {
 				PRINT_DEBUG("get_target_port_group: more "
 					    "than one TPG identifier found!");
+				continue;
+			}
+			if (dscr->length < sizeof(struct vpd83_tpg_dscr)) {
+				PRINT_DEBUG("%s: descr->length too small. "
+					    "got %u. need %zu",
+					    __func__, dscr->length,
+					    sizeof(struct vpd83_tpg_dscr));
 				continue;
 			}
 			p  = (const struct vpd83_tpg_dscr *)dscr->data;

--- a/libmultipath/prioritizers/alua_rtpg.c
+++ b/libmultipath/prioritizers/alua_rtpg.c
@@ -292,8 +292,8 @@ out:
 	return rc;
 }
 
-int
-do_rtpg(int fd, void* resp, long resplen, unsigned int timeout_ms)
+int do_rtpg(int fd, void *resp, long resplen, unsigned int timeout_ms,
+	    unsigned int *len_p)
 {
 	struct rtpg_command	cmd;
 	struct sg_io_hdr	hdr;
@@ -334,6 +334,11 @@ retry:
 		PRINT_DEBUG("do_rtpg: retries exhausted!");
 		return -RTPG_RTPG_FAILED;
 	}
+	if (hdr.resid < 0 || (unsigned int)hdr.resid > hdr.dxfer_len)
+		/* resid failed sanity check*/
+		return -RTPG_RTPG_FAILED;
+	if (len_p)
+		*len_p = hdr.dxfer_len - hdr.resid;
 	PRINT_HEX(resp, resplen);
 
 	return 0;
@@ -342,11 +347,10 @@ retry:
 int
 get_asymmetric_access_state(const struct path *pp, unsigned int tpg)
 {
-	unsigned char		*buf;
-	struct rtpg_data *	tpgd;
+	unsigned char *buf;
 	struct rtpg_tpg_dscr *	dscr;
 	int			rc;
-	unsigned int		buflen;
+	unsigned int buflen, data_len;
 	uint64_t		scsi_buflen;
 	unsigned int		timeout_ms = get_prio_timeout_ms(pp);
 	int fd = pp->fd;
@@ -359,9 +363,14 @@ get_asymmetric_access_state(const struct path *pp, unsigned int tpg)
 		return -RTPG_RTPG_FAILED;
 	}
 	memset(buf, 0, buflen);
-	rc = do_rtpg(fd, buf, buflen, timeout_ms);
+	rc = do_rtpg(fd, buf, buflen, timeout_ms, &data_len);
 	if (rc < 0) {
 		PRINT_DEBUG("%s: do_rtpg returned %d", __func__, rc);
+		goto out;
+	}
+	if (data_len < 4) {
+		PRINT_DEBUG("do_rtpg only returned %u bytes", data_len);
+		rc = -RTPG_RTPG_FAILED;
 		goto out;
 	}
 	scsi_buflen = get_unaligned_be32(&buf[0]) + 4;
@@ -377,14 +386,19 @@ get_asymmetric_access_state(const struct path *pp, unsigned int tpg)
 		}
 		buflen = scsi_buflen;
 		memset(buf, 0, buflen);
-		rc = do_rtpg(fd, buf, buflen, timeout_ms);
+		rc = do_rtpg(fd, buf, buflen, timeout_ms, &data_len);
 		if (rc < 0)
 			goto out;
 	}
+	if ((uint64_t)data_len < get_unaligned_be32(&buf[0]) + 4)
+		PRINT_DEBUG("rtpg data truncated. Read %u of %" PRIu64 " bytes",
+			    data_len, (uint64_t)get_unaligned_be32(&buf[0]) + 4);
 
-	tpgd = (struct rtpg_data *) buf;
 	rc   = -RTPG_TPG_NOT_FOUND;
-	RTPG_FOR_EACH_PORT_GROUP(tpgd, dscr) {
+	for (dscr = (struct rtpg_tpg_dscr *)&buf[4];
+	     (unsigned char *)(dscr + 1) <= buf + data_len &&
+	     (unsigned char *)(dscr->data + dscr->port_count) <= buf + data_len;
+	     dscr = (struct rtpg_tpg_dscr *)(dscr->data + dscr->port_count)) {
 		if (get_unaligned_be16(dscr->tpg) == tpg) {
 			if (rc != -RTPG_TPG_NOT_FOUND) {
 				PRINT_DEBUG("get_asymmetric_access_state: "

--- a/libmultipath/prioritizers/alua_spc3.h
+++ b/libmultipath/prioritizers/alua_spc3.h
@@ -193,50 +193,6 @@ struct vpd83_data {
 
 #define VPD_BUFLEN 4096
 
-/* Returns the max byte offset in the VPD page from the start of the page */
-static inline unsigned int vpd83_max_offs(const struct vpd83_data *p)
-{
-	uint16_t len = get_unaligned_be16(p->length) + 4;
-
-	return len <= VPD_BUFLEN ? len : VPD_BUFLEN;
-}
-
-static inline bool
-vpd83_descr_fits(const struct vpd83_dscr *d, const struct vpd83_data *p)
-{
-	ptrdiff_t max_offs = vpd83_max_offs(p);
-	ptrdiff_t offs = ((const char *)d - (const char *)p);
-
-	/* make sure we can read d->length */
-	if (offs < 0 || offs > max_offs - 4)
-		return false;
-
-	offs += d->length + 4;
-	return offs <= max_offs;
-}
-
-static inline const struct vpd83_dscr *
-vpd83_next_dscr(const struct vpd83_dscr *d, const struct vpd83_data *p)
-{
-	ptrdiff_t offs = ((const char *)d - (const char *)p) + d->length + 4;
-
-	return (const struct vpd83_dscr *)((const char *)p + offs);
-}
-
-/*-----------------------------------------------------------------------------
- * This macro should be used to walk through all identification descriptors
- * defined in the code page 0x83.
- * The argument p is a pointer to the code page 0x83 data and d is used to
- * point to the current descriptor.
- *-----------------------------------------------------------------------------
- */
-#define FOR_EACH_VPD83_DSCR(p, d) \
-		for( \
-			d = p->data;		  \
-			vpd83_descr_fits(d, p);	  \
-			d = vpd83_next_dscr(d, p) \
-		)
-
 /*=============================================================================
  * The following structures and macros are used to call the report target port
  * groups command defined in SPC-3.

--- a/libmultipath/prioritizers/alua_spc3.h
+++ b/libmultipath/prioritizers/alua_spc3.h
@@ -312,15 +312,4 @@ struct rtpg_data {
 	struct rtpg_tpg_dscr		data[0];
 } __attribute__((packed));
 
-#define RTPG_FOR_EACH_PORT_GROUP(p, g) \
-		for( \
-			g = &(p->data[0]); \
-			((char *) g) < ((char *) p) + get_unaligned_be32(p->length); \
-			g = (struct rtpg_tpg_dscr *) ( \
-				((char *) g) + \
-				sizeof(struct rtpg_tpg_dscr) + \
-				g->port_count * sizeof(struct rtpg_tp_dscr) \
-			) \
-		)
-
 #endif /* ALUA_SPC3_H_INCLUDED */

--- a/libmultipath/prioritizers/ana.c
+++ b/libmultipath/prioritizers/ana.c
@@ -76,23 +76,24 @@ static int get_ana_state(__u32 nsid, __u32 anagrpid, void *ana_log,
 	struct nvme_ana_group_desc *ana_desc;
 	size_t offset = sizeof(struct nvme_ana_rsp_hdr);
 	__u32 nr_nsids;
-	size_t nsid_buf_size;
+	__u64 nsid_buf_size;
 	int i;
 	unsigned int j;
 
 	for (i = 0; i < le16_to_cpu(hdr->ngrps); i++) {
-		ana_desc = base + offset;
 
-		offset += sizeof(*ana_desc);
-		if (offset > ana_log_len)
+		if (offset > ana_log_len || sizeof(*ana_desc) > ana_log_len - offset)
 			return -ANA_ERR_GETANAS_OVERFLOW;
+
+		ana_desc = base + offset;
+		offset += sizeof(*ana_desc);
 
 		nr_nsids = le32_to_cpu(ana_desc->nnsids);
 		nsid_buf_size = nr_nsids * sizeof(__le32);
 
-		offset += nsid_buf_size;
-		if (offset > ana_log_len)
+		if (nsid_buf_size > ana_log_len - offset)
 			return -ANA_ERR_GETANAS_OVERFLOW;
+		offset += nsid_buf_size;
 
 		for (j = 0; j < nr_nsids; j++) {
 			if (nsid == le32_to_cpu(ana_desc->nsids[j]))
@@ -101,7 +102,6 @@ static int get_ana_state(__u32 nsid, __u32 anagrpid, void *ana_log,
 
 		if (anagrpid != 0 && anagrpid == le32_to_cpu(ana_desc->grpid))
 			return ana_desc->state;
-
 	}
 	return -ANA_ERR_GETANAS_NOTFOUND;
 }
@@ -113,7 +113,7 @@ static int get_ana_info(struct path * pp)
 	struct nvme_id_ctrl ctrl;
 	struct nvme_id_ns ns;
 	void *ana_log;
-	size_t ana_log_len;
+	uint64_t ana_log_len;
 	bool is_anagrpid_const;
 
 	rc = nvme_id_ctrl_ana(pp->fd, &ctrl);
@@ -148,20 +148,24 @@ static int get_ana_info(struct path * pp)
 	} else
 		ana_log_len += le32_to_cpu(ctrl.mnan) * sizeof(__le32);
 
-	ana_log = malloc(ana_log_len);
+	if (ana_log_len > SIZE_MAX) {
+		condlog(3, "%s: truncating ana log from %zu to %" PRIu64,
+			__func__, SIZE_MAX, ana_log_len);
+		ana_log_len = SIZE_MAX;
+	}
+	ana_log = malloc((size_t)ana_log_len);
 	if (!ana_log)
 		return -ANA_ERR_NO_MEMORY;
 	pthread_cleanup_push(free, ana_log);
-	rc = nvme_ana_log(pp->fd, ana_log, ana_log_len,
+	rc = nvme_ana_log(pp->fd, ana_log, (size_t)ana_log_len,
 			  is_anagrpid_const ? NVME_ANA_LOG_RGO : 0);
 	if (rc) {
 		log_nvme_errcode(rc, pp->dev, "nvme_ana_log");
 		rc = -ANA_ERR_GETANALOG_FAILED;
 	} else
 		rc = get_ana_state(nsid,
-				   is_anagrpid_const ?
-				   le32_to_cpu(ns.anagrpid) : 0,
-				   ana_log, ana_log_len);
+				   is_anagrpid_const ? le32_to_cpu(ns.anagrpid) : 0,
+				   ana_log, (size_t)ana_log_len);
 	pthread_cleanup_pop(1);
 	if (rc >= 0)
 		condlog(4, "%s: ana state = %02x [%s]", pp->dev, rc,

--- a/libmultipath/version.h
+++ b/libmultipath/version.h
@@ -11,9 +11,9 @@
 #ifndef VERSION_H_INCLUDED
 #define VERSION_H_INCLUDED
 
-#define VERSION_CODE 0x000E04
+#define VERSION_CODE 0x000E05
 /* MMDDYY, in hex */
-#define DATE_CODE    0x070A1A
+#define DATE_CODE    0x081B1A
 
 #define PROG    "multipath-tools"
 

--- a/multipathd/multipathd.service.in
+++ b/multipathd/multipathd.service.in
@@ -18,6 +18,7 @@ StartLimitBurst=3
 [Service]
 Type=notify
 NotifyAccess=main
+NonBlocking=true
 ExecStart=@BINDIR@/multipathd -d -s
 ExecReload=@BINDIR@/multipathd reconfigure
 Restart=on-failure

--- a/multipathd/uxlsnr.c
+++ b/multipathd/uxlsnr.c
@@ -86,6 +86,12 @@ enum {
  */
 #define MAX_CLIENTS (16384 - POLLFDS_BASE)
 
+/*
+ * Limit the number of non-root clients to guarantee that there is always
+ * space for root clients
+ */
+#define MAX_NON_ROOT_CLIENTS 256
+
 /* Compile-time error if POLLFD_CHUNK is too small */
 static __attribute__((unused)) char ___a[-(MIN_POLLS <= 0)];
 
@@ -128,7 +134,7 @@ static void dead_client(struct client *c)
 /*
  * handle a new client joining
  */
-static void new_client(int ux_sock)
+static void new_client(int ux_sock, int non_root_clients)
 {
 	struct client *c;
 	struct sockaddr addr;
@@ -149,6 +155,10 @@ static void new_client(int ux_sock)
 	c->fd = fd;
 	c->state = CLT_RECV;
 	c->is_root = _socket_client_is_root(c->fd);
+	if (!c->is_root && non_root_clients >= MAX_NON_ROOT_CLIENTS) {
+		dead_client(c);
+		return;
+	}
 
 	/* put it in our linked list */
 	list_add_tail(&c->node, &clients);
@@ -660,13 +670,15 @@ void *uxsock_listen(int n_socks, long *ux_sock_in, void *trigger_data)
 	sigdelset(&mask, SIGUSR1);
 	while (1) {
 		struct client *c, *tmp;
-		int i, n_pfds, poll_count, num_clients;
+		int i, n_pfds, poll_count, num_clients, non_root_clients;
 		struct timespec __timeout, *timeout;
 
 		/* setup for a poll */
-		num_clients = 0;
+		num_clients = non_root_clients = 0;
 		list_for_each_entry(c, &clients, node) {
 			num_clients++;
+			if (!c->is_root)
+				non_root_clients++;
 		}
 		if (num_clients + POLLFDS_BASE > max_pfds) {
 			struct pollfd *new;
@@ -770,6 +782,8 @@ void *uxsock_listen(int n_socks, long *ux_sock_in, void *trigger_data)
 
 			if (c->error == -ECONNRESET) {
 				condlog(4, "cli[%d]: disconnected", c->fd);
+				if (!c->is_root)
+					non_root_clients--;
 				dead_client(c);
 				if (i < n_pfds)
 					polls[i].fd = -1;
@@ -780,10 +794,10 @@ void *uxsock_listen(int n_socks, long *ux_sock_in, void *trigger_data)
 
 		/* see if we got a new client */
 		if (polls[POLLFD_UX1].revents & POLLIN) {
-			new_client(ux_sock[0]);
+			new_client(ux_sock[0], non_root_clients);
 		}
 		if (polls[POLLFD_UX2].revents & POLLIN) {
-			new_client(ux_sock[1]);
+			new_client(ux_sock[1], non_root_clients);
 		}
 
 		/* handle inotify events on config files */

--- a/multipathd/uxlsnr.c
+++ b/multipathd/uxlsnr.c
@@ -111,6 +111,21 @@ static bool _socket_client_is_root(int fd)
 }
 
 /*
+ * kill off a dead client
+ */
+static void dead_client(struct client *c)
+{
+	int fd = c->fd;
+	list_del_init(&c->node);
+	c->fd = -1;
+	reset_strbuf(&c->reply);
+	if (c->cmdvec)
+		free_keys(c->cmdvec);
+	free(c);
+	close(fd);
+}
+
+/*
  * handle a new client joining
  */
 static void new_client(int ux_sock)
@@ -137,21 +152,6 @@ static void new_client(int ux_sock)
 
 	/* put it in our linked list */
 	list_add_tail(&c->node, &clients);
-}
-
-/*
- * kill off a dead client
- */
-static void dead_client(struct client *c)
-{
-	int fd = c->fd;
-	list_del_init(&c->node);
-	c->fd = -1;
-	reset_strbuf(&c->reply);
-	if (c->cmdvec)
-		free_keys(c->cmdvec);
-	free(c);
-	close(fd);
 }
 
 static void free_polls (void)

--- a/multipathd/uxlsnr.c
+++ b/multipathd/uxlsnr.c
@@ -559,6 +559,8 @@ static int client_state_machine(struct client *c, struct vectors *vecs,
 		return STM_BREAK;
 
 	case CLT_SEND:
+		if (!(revents & POLLOUT))
+			return STM_BREAK;
 		if (get_strbuf_len(&c->reply) == 0)
 			default_reply(c, c->error);
 

--- a/multipathd/uxlsnr.c
+++ b/multipathd/uxlsnr.c
@@ -141,7 +141,7 @@ static void new_client(int ux_sock, int non_root_clients)
 	socklen_t len = sizeof(addr);
 	int fd;
 
-	fd = accept(ux_sock, &addr, &len);
+	fd = accept4(ux_sock, &addr, &len, SOCK_NONBLOCK);
 
 	if (fd == -1)
 		return;
@@ -501,7 +501,8 @@ static int client_state_machine(struct client *c, struct vectors *vecs,
 			return STM_BREAK;
 		} else if (c->len < c->cmd_len) {
 			n = recv(c->fd, c->cmd + c->len, c->cmd_len - c->len, 0);
-			if (n <= 0 && errno != EINTR && errno != EAGAIN) {
+			if (n <= 0 && errno != EINTR && errno != EWOULDBLOCK &&
+			    errno != EAGAIN) {
 				condlog(1, "%s: cli[%d]: error in recv: %m",
 					__func__, c->fd);
 				c->error = -ECONNRESET;
@@ -579,7 +580,8 @@ static int client_state_machine(struct client *c, struct vectors *vecs,
 
 			n = send(c->fd, buf + c->len, c->cmd_len - c->len, MSG_NOSIGNAL);
 			if (n == -1) {
-				if (!(errno == EAGAIN || errno == EINTR))
+				if (!(errno == EAGAIN ||
+				      errno == EWOULDBLOCK || errno == EINTR))
 					c->error = -ECONNRESET;
 			} else
 				c->len += n;


### PR DESCRIPTION
## multipath-tools 0.14.5, 2026/08

### Vulnerability fixes

* [DoS on mulipathd socket by blocking IPC send operations](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-hmcm-9cq4-r2xm)
* [DoS on multipathd socket by exhausting connections]( https://github.com/opensvc/multipath-tools/security/advisories/GHSA-pvp6-c9p3-25fp)
* [Heap Out-of-Bounds Read in Custom Format String Parser via Trailing `%`](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-g5mh-253r-jjw5)
* [Heap out-of-bounds read in device-mapper-multipath ALUA RTPG parsing](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-pxwh-g75c-95pc)
* [kpartx: Heap Out-of-Bounds Read in GPT Header Validation](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-p6rh-9x9j-3hvx)
* [Path traversal in device-mapper-multipath failed_wwids management
  ](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-gr7q-prfc-q636)
* [libmpathpersist PRIN READ FULL STATUS parser — unbounded descriptor rewrite causes root heap overflow](https://github.com/opensvc/multipath-tools/security/advisories/GHSA-hj7j-qr9h-5fv6)

### Bug fixes

* When parsing the device-mapper table of a multipath device, the result for
  path arguments was not checked for `NULL`. This happens if the kernel
  returns an invalid table with missing path arguments. Fix it by adding
  a NULL check.
  Fixes [#155](https://github.com/opensvc/multipath-tools/issues/155),
  [#156](https://github.com/opensvc/multipath-tools/issues/156).

